### PR TITLE
CTE Web Page IOC Scraper v1.2.0: Added an option to choose whether to extract only the domain name or use the full URL

### DIFF
--- a/external_website/CHANGELOG.md
+++ b/external_website/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+## Fixed
+- The pull functionality now includes an option to choose whether to extract only the domain name or use the full URL. For example, if the URL is google.com/abc/xyz, selecting Yes will extract only the domain google.com, while selecting No will retain the full URL google.com/abc/xyz. This setting is applicable only when the indicator type 'URL' is selected in the 'Type of Threat Data to Pull' configuration parameter.
+
 # 1.1.1
 ## Fixed
 - Fixed Bugs in Pull Functionality.

--- a/external_website/manifest.json
+++ b/external_website/manifest.json
@@ -1,10 +1,11 @@
 {
     "name": "Web Page IOC Scraper",
     "id": "external_website",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "description": "This plugin is used to pull IOCs of type URL, Domain, IPv4, IPv6, MD5 and SHA256 from any public website. This plugin does not support sharing of IOCs or performing any actions.",
     "patch_supported": false,
     "push_supported": false,
+    "module": "CTE",
     "configuration": [
         {
             "label": "Website URL",
@@ -54,6 +55,24 @@
             ],
             "mandatory": true,
             "description": "Type of Threat data to pull. Allowed values are SHA256, MD5, URL, Domain, IPv4, IPv6."
+        },
+        {
+            "label": "Extract Domains from URL",
+            "key": "extract_domains",
+            "type": "choice",
+            "choices": [
+                {
+                    "key": "Yes",
+                    "value": "yes"
+                },
+                {
+                    "key": "No",
+                    "value": "no"
+                }
+            ],
+            "mandatory": false,
+            "default": "yes",
+            "description": "Choose whether to extract only the domain name or use the entire URL. For example, if the URL is google.com/abc/xyz, selecting 'Yes' will extract google.com, while selecting 'No' will use the full URL google.com/abc/xyz. Note: This setting is applicable only when the indicator type 'URL' is selected in the 'Type of Threat Data to Pull' configuration parameter."
         }
     ]
 }

--- a/external_website/utils/externalwebsite_constants.py
+++ b/external_website/utils/externalwebsite_constants.py
@@ -34,7 +34,7 @@ CTE Web Page IOC Scraper Plugin constants.
 
 MODULE_NAME = "CTE"
 PLATFORM_NAME = "Web Page IOC Scraper"
-PLUGIN_VERSION = "1.1.1"
+PLUGIN_VERSION = "1.2.0"
 MAX_API_CALLS = 3
 DEFAULT_WAIT_TIME = 60
 THREAT_TYPES = ["sha256", "md5", "url", "domain", "ipv4", "ipv6"]


### PR DESCRIPTION
# 1.2.0
## Fixed
- The pull functionality now includes an option to choose whether to extract only the domain name or use the full URL. For example, if the URL is google.com/abc/xyz, selecting Yes will extract only the domain google.com, while selecting No will retain the full URL google.com/abc/xyz. This setting is applicable only when the indicator type 'URL' is selected in the 'Type of Threat Data to Pull' configuration parameter.