### PR TITLE
CLS Netskope v2.3.0 plugin: Added support for pulling forensics fields for DLP Incidents and added fields to download originalfile and subfile in Incident events.

### DIFF
--- a/netskope_cls/CHANGELOG.md
+++ b/netskope_cls/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0
+## Added
+- Added support for pulling forensics fields for DLP Incidents, To pull and ingest these fields update your Netskope Tenant version to 1.5.0 and CE version to 5.1.2.
+- Added fields to download originalfile and subfile in Incident events.
+
 # 2.2.1
 ## Fixed
 - Fixed compatibility issue when using newer Netskope CLS plugin with older provider versions.

--- a/netskope_cls/manifest.json
+++ b/netskope_cls/manifest.json
@@ -2,10 +2,10 @@
   "name":"Netskope Log Shipper",
   "id":"netskope_cls",
   "netskope":true,
-  "version":"2.2.1",
+  "version":"2.3.0",
   "module":"CLS",
-  "minimum_version":"5.1.0",
-  "minimum_provider_version":"1.0.0",
+  "minimum_version":"5.1.2",
+  "minimum_provider_version":"1.5.0",
   "provider_id":"netskope_provider",
   "patch_supported":true,
   "types":[
@@ -180,6 +180,24 @@
         ],
         "mandatory":false,
         "description":"Types of the events to fetch."
+     },
+     {
+      "label": "Pull DLP Incident Forensics",
+      "key": "incident_forensics",
+      "type": "choice",
+      "choices": [
+          {
+              "key": "Yes",
+              "value": "yes"
+          },
+          {
+              "key": "No",
+              "value": "no"
+          }
+      ],
+      "default": "no",
+      "mandatory": true,
+      "description": "Forensics fields for DLP Incidents will be fetched."
      },
      {
         "label":"Initial Range for Events (in hours)",

--- a/netskope_cls/utils/netskope_cls_constants.py
+++ b/netskope_cls/utils/netskope_cls_constants.py
@@ -1,0 +1,37 @@
+"""
+BSD 3-Clause License
+
+Copyright (c) 2021, Netskope OSS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Netskope CLS constants.
+"""
+
+MODULE_NAME = "CLS"
+PLUGIN_NAME = "Netskope CLS"
+PLUGIN_VERSION = "2.3.0"


### PR DESCRIPTION
# 2.3.0
## Added
- Added support for pulling forensics fields for DLP Incidents, To pull and ingest these fields update your Netskope Tenant version to 1.5.0 and CE version to 5.1.2.
- Added fields to download originalfile and subfile in Incident events.