### PR TITLE
CTO Netskope v2.3.0: Added support for pulling forensics fields for DLP Incidents and added fields to download originalfile and subfile in Incident events.

### DIFF
--- a/netskope_itsm/CHANGELOG.md
+++ b/netskope_itsm/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0
+## Added
+- Added support for pulling forensics fields for DLP Incidents, To pull and ingest these fields update your Netskope Tenant version to 1.5.0 and CE version to 5.1.2.
+- Added fields to download originalfile and subfile in Incident events.
+
 # 2.2.1
 ## Added
 - Added support of filtering using limited operators(LIKE, EQUALS TO) for complex data types.

--- a/netskope_itsm/manifest.json
+++ b/netskope_itsm/manifest.json
@@ -6,10 +6,10 @@
     "pulling_supported": true,
     "receiving_supported": false,
     "sharing_supported": true,
-    "version": "2.2.1",
+    "version": "2.3.0",
     "module": "CTO",
-    "minimum_version": "5.1.1",
-    "minimum_provider_version": "1.3.0",
+    "minimum_version": "5.1.2",
+    "minimum_provider_version": "1.5.0",
     "provider_id": "netskope_provider",
     "supported_subtypes": {
         "alerts": [
@@ -165,6 +165,24 @@
                         "mongo": {}
                     },
                     "description": "Only the alerts/events matching this filter query will be stored and considered for ticket creation. If kept blank all the Alerts and Events will be considered for ticket creation."
+                },
+                {
+                    "label": "Pull DLP Incident Forensics",
+                    "key": "incident_forensics",
+                    "type": "choice",
+                    "choices": [
+                        {
+                            "key": "Yes",
+                            "value": "yes"
+                        },
+                        {
+                            "key": "No",
+                            "value": "no"
+                        }
+                    ],
+                    "default": "no",
+                    "mandatory": false,
+                    "description": "Forensics fields for DLP Incidents will be fetched."
                 }
             ]
         },
@@ -265,7 +283,7 @@
                             "mandatory": true
                         },
                         {
-                            "label": "Infomational",
+                            "label": "Informational",
                             "value": "informational",
                             "multi": false,
                             "mandatory": true

--- a/netskope_itsm/utils/netskope_itsm_constants.py
+++ b/netskope_itsm/utils/netskope_itsm_constants.py
@@ -1,0 +1,58 @@
+"""
+BSD 3-Clause License
+
+Copyright (c) 2021, Netskope OSS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Netskope ITSM constants.
+"""
+
+IGNORED_RAW_KEYS = [
+    "_id",
+    "alert_name",
+    "alert_type",
+    "app",
+    "appcategory",
+    "type",
+    "file_type",
+    "user",
+    "timestamp",
+]
+REQUEST_RATE_LIMIT_DELAY = 30
+REQUEST_RATE_LIMIT_DELAY_ON_ERROR = 2
+MAX_RETRIES_ON_RATE_LIMIT = 3
+INCIDENT_UPDATE_API = "{}/api/v2/incidents/update"
+MODULE_NAME = "CTO"
+PLUGIN_NAME = "Netskope CTO"
+PLUGIN_VERSION = "2.3.0"
+DEFAULT_STATUS_VALUE_MAP = {
+    "New": "new",
+    "In Progress": "in_progress",
+    "Resolved": "closed"
+}
+INCIDENT_BATCH_SIZE = 10


### PR DESCRIPTION
# 2.3.0
## Added
- Added support for pulling forensics fields for DLP Incidents, To pull and ingest these fields update your Netskope Tenant version to 1.5.0 and CE version to 5.1.2.
- Added fields to download originalfile and subfile in Incident events.