### PR TITLE
Tenant Netskope v1.6.1: Added coordinated cleanup of the shared client status iterator so it is removed only once no Netskope plugin (CRE or CLS) is using it. Type cast large ID fields to String to avoid UI rounding them off while rendering.

### DIFF
--- a/netskope_provider/CHANGELOG.md
+++ b/netskope_provider/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.1 (Requires minimum Cloud Exchange version 6.1.0)
+## Added
+- Added coordinated cleanup of the shared client status iterator so it is removed only once no Netskope plugin (CRE or CLS) is using it.
+- Type cast large ID fields to String to avoid UI rounding them off while rendering.
+
 # 1.6.0
 ## Fixed
 - Updated the historical pull logic to ensure that valid events within the requested time range from the last batch are processed.

--- a/netskope_provider/main.py
+++ b/netskope_provider/main.py
@@ -139,7 +139,7 @@ class NetskopeProviderPlugin(PluginBase):
     def parse_incident_events(self, events_data):
         tenant_name = self.configuration.get("tenantName", "").strip().rstrip("/")
         for event in events_data:
-            for key in CONST.STRING_FIELDS:
+            for key in CONST.ID_STRING_FIELDS:
                 if key in event and event[key] is not None:
                     event[key] = str(event[key])
             dlp_incident_id = event.get("dlp_incident_id")
@@ -152,17 +152,84 @@ class NetskopeProviderPlugin(PluginBase):
                 )
         return events_data
 
+    def _stringify_id_fields(self, alert_event_obj, id_string_fields: List[str]):
+        """Convert all ID fields to string in the given records.
+
+        Large 64-bit identifiers (session, connection, incident, request,
+        transaction, and signature IDs) are stringified so their precision is
+        preserved downstream. The full list of ID fields is defined in
+        ``CONST.ID_STRING_FIELDS`` (see alert_id_fields_syslog_mapping.md).
+
+        Args:
+            records (List[dict]): Alert or event records to update in place.
+
+        Returns:
+            List[dict]: The same list with ID fields converted to string.
+        """
+        records = None
+        if isinstance(alert_event_obj, dict) and isinstance(
+            alert_event_obj.get("result"), list
+        ):
+            records = alert_event_obj.get("result")
+        elif isinstance(alert_event_obj, list):
+            records = alert_event_obj
+        else:
+            return alert_event_obj
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            for key in id_string_fields:
+                if key in record and record[key] is not None:
+                    record[key] = str(record[key])
+        return alert_event_obj
+
     def parse_data(self, events: bytes, data_type: str, sub_type: str):
         """Parse incoming data."""
         decompressed_events = gzip.decompress(events)
+        data_type_stripped = data_type.rstrip("s")
+        is_alert_or_event = data_type in [
+            "event",
+            "events",
+            "alert",
+            "alerts",
+        ]
+        id_string_fields = CONST.ALERT_EVENT_ID_FIELD_MAPPING.get(
+            data_type_stripped, {}
+        ).get(sub_type.lower(), [])
         try:
-            if data_type in ['event', 'events'] and sub_type == "incident":
-                return self.parse_incident_events(json.loads(decompressed_events).get("result", []))
-            return json.loads(decompressed_events)
+            alert_event_obj = json.loads(decompressed_events)
+            if is_alert_or_event and sub_type == "incident":
+                return self.parse_incident_events(
+                    alert_event_obj.get("result", [])
+                )
+            if is_alert_or_event and id_string_fields:
+                alert_event_obj = self._stringify_id_fields(
+                    alert_event_obj, id_string_fields
+                )
+            return alert_event_obj
         except json.decoder.JSONDecodeError:
-            if data_type in ['event', 'events'] and sub_type == "incident":
-                return self.parse_incident_events(parse_csv_response(pd.read_csv(StringIO(decompressed_events.decode("utf-8")), keep_default_na=False)))
-            return parse_csv_response(pd.read_csv(StringIO(decompressed_events.decode("utf-8")), keep_default_na=False))
+            parsed_csv_data = parse_csv_response(
+                pd.read_csv(
+                    StringIO(decompressed_events.decode("utf-8")),
+                    keep_default_na=False,
+                )
+            )
+            if is_alert_or_event and sub_type == "incident":
+                return self.parse_incident_events(parsed_csv_data)
+            if is_alert_or_event and id_string_fields:
+                return self._stringify_id_fields(
+                    parsed_csv_data, id_string_fields
+                )
+            return parsed_csv_data
+        except Exception as err:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Unexpected error while parsing data"
+                    f" for {data_type} and sub type {sub_type}. Error: {err}"
+                ),
+                details=traceback.format_exc(),
+            )
+            raise
 
     def transform(self, raw_data, data_type, subtype, **kwargs) -> List:
         """Transform the raw netskope target platform supported."""
@@ -616,78 +683,94 @@ class NetskopeProviderPlugin(PluginBase):
             typeOfField (str): Alert or Event
             sub_type (str): Subtype of alerts or events.
         """
-        typeOfField = typeOfField.rstrip("s")
-        fields = set()
-        for item in items:
-            if not isinstance(item, dict):
-                item = item.dict()
-            item_id = item.get("_id", None)
-            if not sub_type and typeOfField == NetskopeFieldType.ALERT:
-                sub_type = item.get("alert_type", None)
-            elif not sub_type and typeOfField == NetskopeFieldType.EVENT:
-                sub_type = item.get("event_type", None)
-            if not item_id:
-                item_id = item.get("id")
-            for field, field_value in item.items():
-                if field in fields:
-                    continue
-                if not field_value:
-                    continue
-                field_obj = plugin_provider_helper.get_stored_field(field)
-                if (
-                    typeOfField == NetskopeFieldType.WEBTX
-                    and field_obj is None
-                ):
-                    self.logger.info(
-                        f"{self.log_prefix}: The CE platform has detected new field '{field}' in the WebTx logs."
-                        " Configure CLS to use this field if you wish to sent it to the SIEM."
+        try:
+            typeOfField = typeOfField.rstrip("s")
+            fields = set()
+            for item in items:
+                if not isinstance(item, dict):
+                    item = item.dict()
+                item_id = item.get("_id", None)
+                if not sub_type and typeOfField == NetskopeFieldType.ALERT:
+                    sub_type = item.get("alert_type", None)
+                elif not sub_type and typeOfField == NetskopeFieldType.EVENT:
+                    sub_type = item.get("event_type", None)
+                if not item_id:
+                    item_id = item.get("id")
+                for field, field_value in item.items():
+                    if field in fields:
+                        continue
+                    if field_value is None or (
+                        isinstance(field_value, (str, list, dict, tuple, set))
+                        and not field_value
+                    ):
+                        continue
+                    field_obj = plugin_provider_helper.get_stored_field(field)
+                    if (
+                        typeOfField == NetskopeFieldType.WEBTX
+                        and field_obj is None
+                    ):
+                        self.logger.info(
+                            f"{self.log_prefix}: The CE platform has detected new field '{field}' in the WebTx logs."
+                            " Configure CLS to use this field if you wish to sent it to the SIEM."
+                        )
+                        notifier.info(
+                            f"The CE platform has detected new field '{field}' in the WebTx logs."
+                            " Configure CLS to use this field if you wish to sent it to the SIEM."
+                        )
+                    elif sub_type not in CONST.EVENTS.keys() and field_obj is None:
+                        self.logger.info(
+                            f"{self.log_prefix}: The CE platform has detected new field '{field}' in the {sub_type}"
+                            f" alert with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
+                        )
+                        notifier.info(
+                            f"The CE platform has detected new field '{field}' in the {sub_type}"
+                            f" alert with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
+                        )
+                        self.logger.info(
+                            f"{self.log_prefix}: The CE platform has detected new field '{field}' in the {sub_type}"
+                            f" alert with id {item_id}. Configure CTO to use this field if you wish to map to a ticket."
+                        )
+                        notifier.info(
+                            f"The CE platform has detected new field '{field}' in the {sub_type}"
+                            f" alert with id {item_id}. Configure CTO to use this field if you wish to map to a ticket."
+                        )
+                    elif field_obj is None:
+                        self.logger.info(
+                            f"{self.log_prefix}: The CE platform has detected new field '{field}' in the {sub_type}"
+                            f" event with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
+                        )
+                        notifier.info(
+                            f"The CE platform has detected new field '{field}' in the {sub_type}"
+                            f" event with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
+                        )
+
+                    datatype = (
+                        FieldDataType.BOOLEAN
+                        if isinstance(field_value, bool)
+                        else (
+                            FieldDataType.NUMBER
+                            if isinstance(field_value, int)
+                            or isinstance(field_value, float)
+                            else FieldDataType.TEXT
+                        )
                     )
-                    notifier.info(
-                        f"The CE platform has detected new field '{field}' in the WebTx logs."
-                        " Configure CLS to use this field if you wish to sent it to the SIEM."
-                    )
-                elif sub_type not in CONST.EVENTS.keys() and field_obj is None:
-                    self.logger.info(
-                        f"{self.log_prefix}: The CE platform has detected new field '{field}' in the {sub_type}"
-                        f" alert with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
-                    )
-                    notifier.info(
-                        f"The CE platform has detected new field '{field}' in the {sub_type}"
-                        f" alert with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
-                    )
-                    self.logger.info(
-                        f"{self.log_prefix}: The CE platform has detected new field '{field}' in the {sub_type}"
-                        f" alert with id {item_id}. Configure CTO to use this field if you wish to map to a ticket."
-                    )
-                    notifier.info(
-                        f"The CE platform has detected new field '{field}' in the {sub_type}"
-                        f" alert with id {item_id}. Configure CTO to use this field if you wish to map to a ticket."
-                    )
-                elif field_obj is None:
-                    self.logger.info(
-                        f"{self.log_prefix}: The CE platform has detected new field '{field}' in the {sub_type}"
-                        f" event with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
-                    )
-                    notifier.info(
-                        f"The CE platform has detected new field '{field}' in the {sub_type}"
-                        f" event with id {item_id}. Configure CLS to use this field if you wish to sent it to the SIEM."
+                    if field in CONST.ID_STRING_FIELDS:
+                        datatype = FieldDataType.TEXT
+                    plugin_provider_helper.store_new_field(
+                        field, typeOfField, datatype
                     )
 
-                datatype = (
-                    FieldDataType.BOOLEAN
-                    if isinstance(field_value, bool)
-                    else (
-                        FieldDataType.NUMBER
-                        if isinstance(field_value, int)
-                        or isinstance(field_value, float)
-                        else FieldDataType.TEXT
-                    )
-                )
-                plugin_provider_helper.store_new_field(
-                    field, typeOfField, FieldDataType.TEXT if field in CONST.STRING_FIELDS else datatype
-                )
-
-            fields = fields.union(item.keys())
+                fields = fields.union(item.keys())
+        except Exception as err:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Unexpected error occurred while storing"
+                    f"field for {typeOfField}, Sub Type: {sub_type}. Error:"
+                    f" {err}"
+                ),
+                details=traceback.format_exc(),
+            )
+            raise
 
     def client_status_validation(self):
         """Validate client status endpoint."""
@@ -779,6 +862,227 @@ class NetskopeProviderPlugin(PluginBase):
                 details=traceback.format_exc(),
             )
             raise NetskopeProviderPluginException(error_msg)
+
+    def _delete_client_status_iterator(self, configuration=None) -> None:
+        """
+        Delete the client_status iterator from the Netskope tenant and clear
+        its name from the provider's tenant storage.
+
+        Performs the tenant DELETE against
+        ``/api/v2/events/dataexport/iterator/{iterator_name}`` and then unsets
+        the ``client_status_iterator`` key from storage. If no iterator name
+        is currently recorded in storage, this is a no-op.
+
+        Invoked from two places:
+          * ``cleanup`` — full provider/tenant removal (unconditional).
+          * ``unregister_client_status_consumer`` — only when no active
+            subscriber remains.
+
+        Args:
+            configuration (dict, optional): Provider configuration to read
+                ``tenantName`` and ``v2token`` from. Defaults to
+                ``self.configuration`` when not supplied.
+
+        Returns:
+            None
+        """
+        logger_msg = "deleting Client Status Iterator"
+        try:
+            cfg = configuration if configuration is not None else self.configuration
+            tenant_name = (cfg or {}).get("tenantName", "").strip().rstrip("/")
+            v2token = (cfg or {}).get("v2token", "")
+            client_status_iterator = self.storage.get(
+                "client_status_iterator", ""
+            ) if self.storage else ""
+            if not client_status_iterator:
+                return
+            delete_cs_endpoint = (
+                f"{tenant_name}/api/v2/events/dataexport/iterator/{client_status_iterator}"
+            )
+            headers = {
+                'accept': 'application/json',
+                'Authorization': f'Bearer {v2token}'
+            }
+            logger_msg = (
+                f"Deleting Client Status Iterator {client_status_iterator} "
+                f"for tenant {tenant_name}"
+            )
+            self.netskope_provider_helper.api_helper(
+                logger_msg=logger_msg,
+                url=delete_cs_endpoint,
+                method="DELETE",
+                headers=headers,
+                proxies=self.proxy,
+                is_handle_error_required=True
+            )
+            plugin_provider_helper.update_tenant_storage(
+                self.name, update_unset={"client_status_iterator": ""}
+            )
+            if isinstance(self.storage, dict):
+                self.storage.pop("client_status_iterator", None)
+        except NetskopeProviderPluginException:
+            pass
+        except Exception as e:
+            self.logger.error(
+                f"{self.log_prefix}: "
+                f"Unexpected error occurred while {logger_msg}: {e}"
+            )
+
+    def _has_active_client_status_subscriber(self) -> bool:
+        """
+        Check whether any consumer is currently subscribed to client_status.
+
+        Walks the ``client_status_subscribers`` map (shape:
+        ``{module: {config_name: bool}}``) in the provider's tenant storage
+        and returns True if any leaf is truthy. A ``True`` leaf means the
+        owning plugin configuration is actively pulling client_status; a
+        ``False`` leaf means the configuration exists but has opted out.
+
+        Used by ``unregister_client_status_consumer`` to decide whether the
+        iterator can be deleted.
+
+        Returns:
+            bool: True if at least one config across any module has its
+                subscriber leaf set to True; False otherwise (including when
+                the map is missing or empty).
+        """
+        subs = (self.storage or {}).get("client_status_subscribers", {}) or {}
+        if not isinstance(subs, dict):
+            return False
+        for configs in subs.values():
+            if not isinstance(configs, dict):
+                continue
+            if any(bool(v) for v in configs.values()):
+                return True
+        return False
+
+    def register_client_status_consumer(
+        self,
+        module: Literal["cls", "cre"],
+        config_name: str,
+    ) -> None:
+        """
+        Register a CLS or CRE plugin configuration as an active consumer of
+        the shared client_status iterator.
+
+        Bundles two operations that must happen together:
+          1. Run ``client_status_validation`` — validate the existing iterator
+             or create a new one (with the 404 -> recreate self-heal).
+          2. Set ``client_status_subscribers.<module>.<config_name>`` to True
+             in the provider's tenant storage via dot-notation, so concurrent
+             writes by the other module touch a different leaf and don't
+             clobber this one.
+
+        Called by CLS and CRE during ``validate`` when the plugin is saved
+        with ``clientstatus`` in its requested event types. Replaces the
+        previous direct call to ``client_status_validation`` so the
+        subscriber registry stays consistent.
+
+        Args:
+            module (Literal["cls", "cre"]): The consuming module.
+            config_name (str): The plugin configuration name (``self.name``
+                in the calling plugin). Must not contain ``.`` or start with
+                ``$`` since it becomes a MongoDB field key.
+
+        Returns:
+            None
+
+        Raises:
+            NetskopeProviderPluginException: Propagated from
+                ``client_status_validation`` if iterator creation fails.
+        """
+        self.client_status_validation()
+        leaf_path = f"client_status_subscribers.{module}.{config_name}"
+        plugin_provider_helper.update_tenant_storage(
+            self.name, update_set={leaf_path: True}
+        )
+        if isinstance(self.storage, dict):
+            self.storage.setdefault(
+                "client_status_subscribers", {}
+            ).setdefault(module, {})[config_name] = True
+
+    def unregister_client_status_consumer(
+        self,
+        module: Literal["cls", "cre"],
+        config_name: str,
+        deleted: bool = False,
+    ) -> None:
+        """
+        Release a consumer's hold on the shared client_status iterator and
+        delete the iterator only when no other consumer is still subscribed.
+
+        Two release modes:
+          * ``deleted=False`` (opt-out): the plugin config still exists but
+            no longer needs ``clientstatus``. The leaf
+            ``client_status_subscribers.<module>.<config_name>`` is set to
+            False so the registry still knows the config.
+          * ``deleted=True`` (plugin removal): the leaf is unset entirely so
+            the map does not accumulate dead configs.
+
+        After updating its own leaf, the method evaluates whether any leaf
+        across any module is still True (via
+        ``_has_active_client_status_subscriber``). If none are, it invokes
+        ``_delete_client_status_iterator`` to delete the iterator from the
+        tenant and clear ``client_status_iterator`` from storage. Otherwise
+        the iterator is left alone — another consumer still owns it.
+
+        Migration safety: if the subscriber registry did not exist before
+        this call (a pre-upgrade tenant where the iterator was created by
+        the old, unsubscribed code path), the method records its leaf but
+        skips iterator deletion. A subsequent unregister, by which point
+        both modules will have written their leaves, re-evaluates normally.
+
+        Called by CLS and CRE during ``validate`` when the plugin is saved
+        without ``clientstatus``, and during their ``cleanup`` (with
+        ``deleted=True``) when the plugin is removed.
+
+        Args:
+            module (Literal["cls", "cre"]): The consuming module.
+            config_name (str): The plugin configuration name. Must not
+                contain ``.`` or start with ``$`` since it becomes a MongoDB
+                field key.
+            deleted (bool): True when the calling plugin configuration is
+                being deleted (unset the leaf); False when the plugin is
+                merely opting out of ``clientstatus`` (set the leaf to
+                False). Defaults to False.
+
+        Returns:
+            None
+        """
+        pre_subs = (self.storage or {}).get("client_status_subscribers", {}) or {}
+        pre_existed = isinstance(pre_subs, dict) and any(
+            isinstance(v, dict) and len(v) > 0 for v in pre_subs.values()
+        )
+
+        leaf_path = f"client_status_subscribers.{module}.{config_name}"
+        if deleted:
+            plugin_provider_helper.update_tenant_storage(
+                self.name, update_unset={leaf_path: ""}
+            )
+            if isinstance(self.storage, dict):
+                mod = self.storage.get(
+                    "client_status_subscribers", {}
+                ).get(module, {})
+                if isinstance(mod, dict):
+                    mod.pop(config_name, None)
+        else:
+            plugin_provider_helper.update_tenant_storage(
+                self.name, update_set={leaf_path: False}
+            )
+            if isinstance(self.storage, dict):
+                self.storage.setdefault(
+                    "client_status_subscribers", {}
+                ).setdefault(module, {})[config_name] = False
+
+        # Migration safety: if no subscriber leaf existed before this call,
+        # treat ownership as unknown and skip iterator deletion. The next
+        # unregister after both modules have been through the new path will
+        # re-evaluate.
+        if not pre_existed:
+            return
+
+        if not self._has_active_client_status_subscriber():
+            self._delete_client_status_iterator()
 
     def update_incident_enrichment_option_to_storage(
         self,
@@ -1048,44 +1352,12 @@ class NetskopeProviderPlugin(PluginBase):
 
     def cleanup(self, configuration, is_validation=False) -> None:
         """Remove all related dependencies of the record before its deletion, ensuring data integrity."""
-        # Delete the Client Status iterator from the storage
-        try:
-            tenant_name = configuration.get("tenantName", "").strip().rstrip("/")
-            v2token = configuration.get("v2token", "")
-            client_status_iterator = self.storage.get(
-                "client_status_iterator", ""
-            ) if self.storage else ""
-            if client_status_iterator:
-                delete_cs_endpoint = (
-                    f"{tenant_name}/api/v2/events/dataexport/iterator/{client_status_iterator}"
-                )
-                headers = {
-                    'accept': 'application/json',
-                    'Authorization': f'Bearer {v2token}'
-                }
-                logger_msg = (
-                    f"Deleting Client Status Iterator {client_status_iterator} "
-                    f"for tenant {tenant_name}"
-                )
-                self.netskope_provider_helper.api_helper(
-                    logger_msg=logger_msg,
-                    url=delete_cs_endpoint,
-                    method="DELETE",
-                    headers=headers,
-                    proxies=self.proxy,
-                    is_handle_error_required=True
-                )
-                update_unset = {"client_status_iterator": ""}
-                plugin_provider_helper.update_tenant_storage(
-                    self.name, update_unset=update_unset
-                )
-        except NetskopeProviderPluginException:
-            pass
-        except Exception as e:
-            self.logger.error(
-                f"{self.log_prefix}: "
-                f"Unexpected error occurred while {logger_msg}: {e}"
-            )
+        tenant_name = configuration.get("tenantName", "").strip().rstrip("/")
+        # Full provider/tenant removal: drop the client_status iterator unconditionally.
+        # In-flight CLS / CRE plugin saves go through
+        # (un)register_client_status_consumer instead, so the iterator survives
+        # while any consumer is still subscribed.
+        self._delete_client_status_iterator(configuration)
         if not is_validation:
             tenants = plugin_provider_helper.list_tenants()
             if len(tenants) == 1:

--- a/netskope_provider/manifest.json
+++ b/netskope_provider/manifest.json
@@ -8,9 +8,9 @@
         "webtx"
     ],
     "netskope": true,
-    "version": "1.6.0",
+    "version": "1.6.1",
     "module": "Tenant",
-    "minimum_version": "6.0.0",
+    "minimum_version": "6.1.0",
     "description": "This plugin is required to configure Netskope Tenant in Cloud Exchange. The Netskope Tenant will be used by the Netskope plugins to fetch the required data for each module.",
     "configuration": [
         {

--- a/netskope_provider/utils/constants.py
+++ b/netskope_provider/utils/constants.py
@@ -36,8 +36,7 @@ from netskope_api.iterator.const import Const
 import os
 
 MODULE_NAME = "TENANT"
-PLUGIN_VERSION = "1.6.0"
-MAXIMUM_CE_VERSION = "5.1.2"
+PLUGIN_VERSION = "1.6.1"
 PLATFORM_NAME = "Netskope"
 MAX_API_CALLS = 4
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -98,7 +97,22 @@ if isinstance(RETRY_COUNT_FOR_PULLING, str) and RETRY_COUNT_FOR_PULLING.isnumeri
         RETRY_COUNT_FOR_PULLING = DEFAULT_RETRY_COUNT
 else:
     RETRY_COUNT_FOR_PULLING = DEFAULT_RETRY_COUNT
-STRING_FIELDS = ['dlp_incident_id', 'connection_id', 'app_session_id', 'dlp_parent_id', 'browser_session_id']
+# ID fields converted to string so large 64-bit identifiers keep their
+# precision downstream (see alert_id_fields_syslog_mapping.md). A set is used
+# for O(1) membership checks since this lookup runs for every field on every
+# log record.
+ID_STRING_FIELDS = {
+    "app_session_id",
+    "browser_session_id",
+    "connection_id",
+    "dlp_incident_id",
+    "dlp_parent_id",
+    "incident_id",
+    "latest_incident_id",
+    "request_id",
+    "signature_id",
+    "transaction_id",
+}
 DLP_INCIDENT_FORENSICS_ENDPOINT = "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/forensics"
 DLP_INCIDENT_ORIGINAL_FILE_ENDPOINT = "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/originalfile"
 DLP_INCIDENT_SUB_FILE_ENDPOINT = "{base_url}/api/v2/incidents/dlpincidents/{dlp_incident_id}/subfile"
@@ -106,3 +120,113 @@ DLP_INCIDENT_SUB_FILE_ENDPOINT = "{base_url}/api/v2/incidents/dlpincidents/{dlp_
 RATELIMIT_REMAINING = "ratelimit-remaining"
 # Rate limit RESET value is in seconds
 RATELIMIT_RESET = "ratelimit-reset"
+
+ALERT_EVENT_ID_FIELD_MAPPING = {
+    "alert": {
+        "c2": [
+            "signature_id",
+            "transaction_id"
+        ],
+        "content": [
+            "dlp_incident_id",
+            "incident_id"
+        ],
+        "ctep": [
+            "signature_id",
+            "transaction_id"
+        ],
+        "dlp": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "dlp_incident_id",
+            "dlp_parent_id",
+            "incident_id",
+            "request_id",
+            "transaction_id"
+        ],
+        "ips": [
+            "signature_id",
+            "transaction_id"
+        ],
+        "malsite": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "incident_id",
+            "request_id",
+            "transaction_id"
+        ],
+        "malware": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "incident_id",
+            "request_id",
+            "transaction_id"
+        ],
+        "policy": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "incident_id",
+            "request_id",
+            "transaction_id"
+        ],
+        "remediation": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "incident_id",
+            "request_id",
+            "transaction_id"
+        ],
+        "uba": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "incident_id",
+            "request_id",
+            "transaction_id"
+        ],
+        "watchlist": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "dlp_incident_id",
+            "dlp_parent_id",
+            "incident_id",
+            "request_id",
+            "transaction_id"
+        ]
+    },
+    "event": {
+        "application": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "dlp_incident_id",
+            "dlp_parent_id",
+            "request_id",
+            "transaction_id"
+        ],
+        "endpoint": [
+            "dlp_incident_id",
+            "incident_id"
+        ],
+        "incident": [
+            "app_session_id",
+            "connection_id",
+            "dlp_incident_id",
+            "dlp_parent_id",
+            "latest_incident_id"
+        ],
+        "page": [
+            "app_session_id",
+            "browser_session_id",
+            "connection_id",
+            "request_id",
+            "transaction_id"
+        ]
+    }
+}

--- a/netskope_provider/utils/iterator_api_helper.py
+++ b/netskope_provider/utils/iterator_api_helper.py
@@ -47,7 +47,6 @@ from .constants import (
     PLATFORM_NAME,
     MODULE_NAME,
     MAX_API_CALLS,
-    MAXIMUM_CE_VERSION,
     DEFAULT_WAIT_TIME,
     RATELIMIT_RESET,
     RATELIMIT_REMAINING,
@@ -96,33 +95,6 @@ class NetskopePluginHelper(object):
         self.logger = logger
         self.plugin_name = plugin_name
         self.plugin_version = plugin_version
-        self.resolution_support = version.parse(CE_VERSION) > version.parse(
-            MAXIMUM_CE_VERSION
-        )
-        self.is_ce_version_greater_than_512 = self.resolution_support
-        # Patch logger methods to handle resolution parameter compatibility
-        self._patch_logger_methods()
-
-    def _patch_logger_methods(self):
-        """patch logger methods to handle resolution parameter
-        compatibility."""
-        # Store original methods
-        original_error = self.logger.error
-
-        def patched_error(
-            message=None, details=None, resolution=None, **kwargs
-        ):
-            """Patched error method that handles resolution compatibility."""
-            log_kwargs = {"message": message}
-            if details:
-                log_kwargs["details"] = details
-            if resolution and self.resolution_support:
-                log_kwargs["resolution"] = resolution
-            log_kwargs.update(kwargs)
-            return original_error(**log_kwargs)
-
-        # Replace logger methods with patched versions
-        self.logger.error = patched_error
 
     def _add_user_agent(self, headers: Union[Dict, None] = None) -> Dict:
         """Add User-Agent in the headers for third-party requests.
@@ -697,22 +669,25 @@ class NetskopePluginHelper(object):
                 logger_msg,
                 is_validation=is_validation
             )
+
     def check_iterator_status(
         self,
         tenant_hostname,
+        tenant_configuration_name,
         headers,
         proxies=None,
         tenant_storage=None
     ):
         """
         This function is used to check the status of the Client status iterator.
-        
+
         Parameters:
         tenant_hostname (str): The tenant hostname.
+        tenant_configuration_name (str): The tenant configuration name.
         headers (dict): The headers to be sent with the API call.
         proxies (dict): The proxy configuration in case of proxy enabled.
         tenant_storage (dict): The tenant configuration storage.
-        
+
         Returns:
         bool: True if the iterator is ready else False.
         """
@@ -725,10 +700,11 @@ class NetskopePluginHelper(object):
         else:
             iterator_name = self.create_iterator(
                 tenant_url=tenant_hostname,
-                tenant_configuration_name=self.tenant_name,
+                tenant_configuration_name=tenant_configuration_name,
                 headers=headers,
-                iterator_name=CLIENT_STATUS_ITERATOR_NAME
-            )        
+                iterator_name=CLIENT_STATUS_ITERATOR_NAME,
+                proxies=proxies,
+            )
         logger_msg = (
             "Checking status of iterator "
             f"with name {iterator_name}"

--- a/netskope_provider/utils/iterator_helper.py
+++ b/netskope_provider/utils/iterator_helper.py
@@ -522,6 +522,7 @@ class NetskopeClient:
                 else:
                     is_iterator_ready = self.netskope_api_plugin_helper.check_iterator_status(
                         tenant_hostname=self.tenant_hostname,
+                        tenant_configuration_name=self.tenant_name,
                         headers=self.headers,
                         proxies=self.proxy,
                         tenant_storage=self.tenant.get("storage", {})


### PR DESCRIPTION
# 1.6.1 (Requires minimum Cloud Exchange version 6.1.0)
## Added
- Added coordinated cleanup of the shared client status iterator so it is removed only once no Netskope plugin (CRE or CLS) is using it.
- Type cast large ID fields to String to avoid UI rounding them off while rendering.