### PR TITLE
CRE Netskope v1.8.0: Added support for the Add to Destination Profile, Add to DNS Profile, Add to Service Profile, Create Device Classification, updated the Add Host to Private App action and added coordinated cleanup of the shared client status iterator so it is removed only once no Netskope plugin (CRE or CLS) is using it.

### DIFF
--- a/netskope_ztre/CHANGELOG.md
+++ b/netskope_ztre/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.8.0 (Requires minimum Cloud Exchange version 6.1.0 and minimum Netskope Provider version 1.6.1)
+## Added
+- Added support for the 'Add to Destination Profile' action on Netskope.
+- Added support for the 'Add to DNS Profile' action on Netskope.
+- Added support for the 'Add to Service Profile' action on Netskope.
+- Added support for the 'Create Device Classification' action on Netskope.
+- Added coordinated cleanup of the shared client status iterator so it is removed only once no Netskope plugin (CRE or CLS) is using it.
+## Changed
+- Updated the 'Add Host to Private App' action to roll hosts over into additional private apps when a private app reaches its host limit, with a 'Skip Excess Hosts' option to skip the excess hosts instead.
+
 # 1.7.0
 ## Added
 - Added the required `hostname` parameter to the device payload for device tagging APIs.

--- a/netskope_ztre/main.py
+++ b/netskope_ztre/main.py
@@ -31,12 +31,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Netskope CRE plugin."""
 
+import copy
 import json
 import re
 import time
 import traceback
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from netskope.common.utils import (
     AlertsHelper,
@@ -63,6 +64,7 @@ from .utils.constants import (
     REGEX_HOST,
     REGEX_EMAIL,
     REGEX_TAG,
+    REGEX_FOR_DOMAIN,
     MODULE_NAME,
     PLUGIN,
     PLUGIN_VERSION,
@@ -78,6 +80,7 @@ from .utils.constants import (
     APPLICATIONS_BATCH_SIZE,
     TAG_APP_TAG_LENGTH,
     TAG_DEVICE_TAG_LENGTH,
+    PRIVATE_APP_TAG_MAX_LENGTH,
     TAG_DEVICE_BATCH_SIZE,
     TAG_EXISTS,
     DEVICE_FIELD_MAPPING,
@@ -85,10 +88,60 @@ from .utils.constants import (
     TAG_CACHE_PAGE_SIZE,
     DEVICE_BULK_TAG_INTER_BATCH_SLEEP,
     TAG_ACTION_LABEL_MAP,
+    PENDING_CHANGES_DETECTED,
+    V2_SERVICE_PROFILE,
+    V2_SERVICE_PROFILE_BY_ID,
+    SERVICE_PROFILE_TYPE_CUSTOM,
+    SERVICE_PROFILE_PAGE_SIZE,
+    MAX_DESTINATION_PROFILE_NAME_LENGTH,
+    MAX_DESTINATION_PROFILE_DESC_LENGTH,
+    DESTINATION_PROFILE_NAME_FORBIDDEN_CHARS,
+    DESTINATION_PROFILE_PAYLOAD_LIMIT,
+    DESTINATION_PROFILE_PAYLOAD_SAFETY_BUFFER,
+    DESTINATION_PROFILE_VALUES_PER_APPEND,
+    DESTINATION_PROFILE_REGEX_TOTAL_LIMIT,
+    MATCH_TYPE_OPTIONS,
+    MAX_DNS_PROFILE_NAME_LENGTH,
+    MAX_DNS_PROFILE_DESC_LENGTH,
+    DNS_PROFILE_FORBIDDEN_CHARS,
+    MAX_SERVICE_PROFILE_NAME_LENGTH,
+    MAX_SERVICE_PROFILE_DESC_LENGTH,
+    DNS_PROFILE_ACTION_TYPE_OPTIONS,
+    BLOCK_ALL_EXCEPT_ALLOW_LIST_OPTIONS,
+    CUSTOM_SEPARATOR,
+    CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION,
+    OPERATION_OPTIONS,
+    SERVICE_PROFILE_OPERATION_OPTIONS,
+    DNS_PROFILE_PAYLOAD_LIMIT,
+    DNS_PROFILE_PAYLOAD_SAFETY_BUFFER,
+    DEVICE_CLASSIFICATION_PAGE_SIZE,
+    MAX_DEVICE_CLASSIFICATION_NAME_LENGTH,
+    DEVICE_CLASSIFICATION_DEFAULT_DESCRIPTION,
+    DEVICE_CLASSIFICATION_OS_OPTIONS,
+    DEVICE_CLASSIFICATION_OPERATOR_OPTIONS,
+    DESTINATION_PROFILE_ACTION_PARAMS,
+    DNS_PROFILE_ACTION_PARAMS,
+    SERVICE_PROFILE_ACTION_PARAMS,
+    DEVICE_CLASSIFICATION_ACTION_PARAMS,
 )
-from .utils.helper import NetskopePluginHelper, NetskopeException
+from .utils.helper import (
+    NetskopePluginHelper,
+    NetskopeException,
+    _capitalize_first,
+)
 
 plugin_provider_helper = PluginProviderHelper()
+
+
+class PrivateAppLimitReachedError(Exception):
+    """Raised when the tenant's maximum private app count is reached.
+
+    Netskope returns this as an HTTP 200 with a body of
+    ``{"status": "error", "message": "The maximum number ... has been
+    reached."}`` when a private app create would exceed the tenant limit.
+    It is treated as a non-fatal stop signal during roll-over (the
+    remaining hosts are skipped) rather than a hard action failure.
+    """
 
 
 class NetskopePlugin(PluginBase):
@@ -154,41 +207,71 @@ class NetskopePlugin(PluginBase):
                     EntityField(
                         name="email",
                         type=EntityFieldType.STRING,
+                        description=(
+                            "User email address. This field can be used to"
+                            " merge User records with other CRE plugins."
+                        ),
                         required=True,
                     ),
-                    EntityField(name="ubaScore", type=EntityFieldType.NUMBER),
                     EntityField(
-                        name="policyName", type=EntityFieldType.STRING
+                        name="ubaScore",
+                        type=EntityFieldType.NUMBER,
+                        description="User Behavior Analytics risk score.",
                     ),
                     EntityField(
-                        name="cci", type=EntityFieldType.NUMBER
+                        name="policyName",
+                        type=EntityFieldType.STRING,
+                        description="Security policy name applied to user.",
                     ),
                     EntityField(
-                        name="ccl", type=EntityFieldType.STRING
+                        name="cci",
+                        type=EntityFieldType.NUMBER,
+                        description="Netskope Confidence Correlation Index.",
                     ),
                     EntityField(
-                        name="deviceClassification", type=EntityFieldType.STRING
+                        name="ccl",
+                        type=EntityFieldType.STRING,
+                        description="Netskope Confidence Correlation Level.",
                     ),
                     EntityField(
-                        name="policyAction", type=EntityFieldType.LIST
+                        name="deviceClassification",
+                        type=EntityFieldType.STRING,
+                        description="Device classification category.",
                     ),
                     EntityField(
-                        name="severity", type=EntityFieldType.STRING
+                        name="policyAction",
+                        type=EntityFieldType.LIST,
+                        description="Policy actions applied to traffic.",
                     ),
                     EntityField(
-                        name="destinationIP", type=EntityFieldType.STRING
+                        name="severity",
+                        type=EntityFieldType.STRING,
+                        description="Security event severity level.",
                     ),
                     EntityField(
-                        name="sourceRegion", type=EntityFieldType.STRING
+                        name="destinationIP",
+                        type=EntityFieldType.STRING,
+                        description="Destination server IP address.",
                     ),
                     EntityField(
-                        name="sourceIP", type=EntityFieldType.STRING
+                        name="sourceRegion",
+                        type=EntityFieldType.STRING,
+                        description="Geographic region of source.",
                     ),
                     EntityField(
-                        name="userIP", type=EntityFieldType.STRING
+                        name="sourceIP",
+                        type=EntityFieldType.STRING,
+                        description="Source IP address.",
                     ),
                     EntityField(
-                        name="policyID", type=EntityFieldType.STRING
+                        name="userIP",
+                        type=EntityFieldType.STRING,
+                        description="User's public IP address.",
+                    ),
+                    EntityField(
+                        name="policyID",
+                        type=EntityFieldType.STRING,
+                        description="Unique policy identifier.",
                     ),
                 ],
             ),
@@ -196,28 +279,65 @@ class NetskopePlugin(PluginBase):
                 name="Applications",
                 fields=[
                     EntityField(
-                        name="applicationId", type=EntityFieldType.STRING
+                        name="applicationId",
+                        type=EntityFieldType.STRING,
+                        description="Unique application identifier.",
                     ),
                     EntityField(
                         name="applicationName",
                         type=EntityFieldType.STRING,
                         required=True,
-                    ),
-                    EntityField(name="vendor", type=EntityFieldType.STRING),
-                    EntityField(name="source", type=EntityFieldType.STRING),
-                    EntityField(name="cci", type=EntityFieldType.NUMBER),
-                    EntityField(name="ccl", type=EntityFieldType.STRING),
-                    EntityField(
-                        name="categoryName", type=EntityFieldType.STRING
-                    ),
-                    EntityField(name="users", type=EntityFieldType.LIST),
-                    EntityField(name="deepLink", type=EntityFieldType.STRING),
-                    EntityField(name="customTags", type=EntityFieldType.LIST),
-                    EntityField(
-                        name="discoveryDomains", type=EntityFieldType.LIST
+                        description="Application name.",
                     ),
                     EntityField(
-                        name="steeringDomains", type=EntityFieldType.LIST
+                        name="vendor",
+                        type=EntityFieldType.STRING,
+                        description="Software vendor or publisher.",
+                    ),
+                    EntityField(
+                        name="source",
+                        type=EntityFieldType.STRING,
+                        description="Application discovery source.",
+                    ),
+                    EntityField(
+                        name="cci",
+                        type=EntityFieldType.NUMBER,
+                        description="Netskope Confidence Correlation Index.",
+                    ),
+                    EntityField(
+                        name="ccl",
+                        type=EntityFieldType.STRING,
+                        description="Netskope Confidence Correlation Level.",
+                    ),
+                    EntityField(
+                        name="categoryName",
+                        type=EntityFieldType.STRING,
+                        description="Application category classification.",
+                    ),
+                    EntityField(
+                        name="users",
+                        type=EntityFieldType.LIST,
+                        description="Users accessing application.",
+                    ),
+                    EntityField(
+                        name="deepLink",
+                        type=EntityFieldType.STRING,
+                        description="Direct dashboard link to application.",
+                    ),
+                    EntityField(
+                        name="customTags",
+                        type=EntityFieldType.LIST,
+                        description="Custom tags assigned to application.",
+                    ),
+                    EntityField(
+                        name="discoveryDomains",
+                        type=EntityFieldType.LIST,
+                        description="Domains for application discovery.",
+                    ),
+                    EntityField(
+                        name="steeringDomains",
+                        type=EntityFieldType.LIST,
+                        description="Domains for steering policies.",
                     ),
                 ],
             ),
@@ -228,85 +348,118 @@ class NetskopePlugin(PluginBase):
                         name="Device ID",
                         type=EntityFieldType.STRING,
                         required=True,
+                        description="Unique device identifier.",
                     ),
                     EntityField(
                         name="Hostname",
                         type=EntityFieldType.STRING,
                         required=True,
+                        description=(
+                            "Device hostname or computer name. This field"
+                            " can be used to merge device records with other"
+                            " CRE plugins."
+                        ),
                     ),
                     EntityField(
                         name="Netskope Device UID",
                         type=EntityFieldType.STRING,
                         required=True,
+                        description="Unique identifier assigned by Netskope.",
                     ),
                     EntityField(
                         name="Mac Addresses",
-                        type=EntityFieldType.LIST
+                        type=EntityFieldType.LIST,
+                        description="Device MAC addresses.",
                     ),
                     EntityField(
                         name="Last Connected from Private IP",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Last private IP connection.",
                     ),
                     EntityField(
                         name="Last Connected from Public IP",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Last public IP connection.",
                     ),
                     EntityField(
                         name="Device Serial Number",
                         type=EntityFieldType.STRING,
                         required=True,
+                        description=(
+                            "Manufacturer device serial number. "
+                            "This field can be used to merge device"
+                            " records with other CRE Plugins."
+                        ),
                     ),
                     EntityField(
                         name="Operating System",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Device operating system name.",
                     ),
                     EntityField(
                         name="Operating System Version",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Operating system version number.",
                     ),
                     EntityField(
                         name="Device Make",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Device manufacturer brand.",
                     ),
                     EntityField(
                         name="Device Model",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Device model name or number.",
                     ),
                     EntityField(
                         name="Last Updated Timestamp",
-                        type=EntityFieldType.DATETIME
+                        type=EntityFieldType.DATETIME,
+                        description="Last device information update time.",
                     ),
                     EntityField(
                         name="Management ID",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Device management system identifier.",
                     ),
                     EntityField(
                         name="Steering Config",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Applied steering policy configuration.",
                     ),
                     EntityField(
                         name="Region",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Device geographic region",
                     ),
                     EntityField(
                         name="User Name",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description=(
+                            "Primary device user name. This field can be used"
+                            " to merge User records from other CRE plugins or"
+                            " make this field as unique and use it as a"
+                            " reference in other plugin that supports user"
+                            " name reference field."
+                        ),
                     ),
                     EntityField(
                         name="User Key",
                         type=EntityFieldType.LIST,
                         required=True,
+                        description="Device user identifiers or keys",
                     ),
                     EntityField(
                         name="Device Classification Status",
-                        type=EntityFieldType.STRING
+                        type=EntityFieldType.STRING,
+                        description="Current device classification status",
                     ),
                     EntityField(
                         name="Tags",
-                        type=EntityFieldType.LIST
+                        type=EntityFieldType.LIST,
+                        description="Tags assigned to the device",
                     ),
                 ],
-            )
+            ),
         ]
 
     def _convert_string_to_list(self, data_object: Dict, key: str) -> Dict:
@@ -433,7 +586,7 @@ class NetskopePlugin(PluginBase):
                 return records
             else:
                 return [extracted_fields] if extracted_fields else []
-        
+
         # If the CSV response has multiple values for mac address field they
         # are separated by '|' and the tenant plugin parses it into a list
         # of strings but for single value in mac address field it is parsed
@@ -443,8 +596,8 @@ class NetskopePlugin(PluginBase):
                 data_object=extracted_fields,
                 key="Mac Addresses",
             )
-            # The userkey earlier was going as str, but 
-            # in the netity mapping we have made it as list now 
+            # The userkey earlier was going as str, but
+            # in the netity mapping we have made it as list now
             # so it should also be returned as list
             extracted_fields = self._convert_string_to_list(
                 data_object=extracted_fields,
@@ -1155,7 +1308,7 @@ class NetskopePlugin(PluginBase):
                     f"out of {total_batches} batch(es) for device "
                     f"with UID '{device_uid}'."
                 )
-            
+
             self.logger.debug(
                 f"{self.log_prefix}: Successfully fetched tags for "
                 f"{successful_batches} batch(es).{log_msg}"
@@ -1269,6 +1422,2873 @@ class NetskopePlugin(PluginBase):
         else:
             raise ValueError(f"Unsupported entity '{entity}'")
 
+    def _get_tenant_and_headers(self) -> Tuple[str, Dict]:
+        """Return the tenant base URL and the v2-token auth headers.
+
+        The Add to Destination/DNS/Service Profile and Create Device
+        Classification actions all authenticate the same way against the
+        shared Netskope provider tenant. This resolves the tenant base
+        URL and builds the ``Netskope-API-Token`` header once so the
+        per-action helpers do not each repeat the same setup.
+
+        Returns:
+            Tuple[str, Dict]: ``(tenant_name, headers)`` where
+                ``tenant_name`` is the stripped tenant base URL and
+                ``headers`` carries the resolved v2 API token.
+        """
+        tenant_name = (
+            self.tenant.parameters.get("tenantName", "").strip()
+        )
+        headers = {
+            "Netskope-API-Token": resolve_secret(
+                self.tenant.parameters.get("v2token", "")
+            )
+        }
+        return tenant_name, headers
+
+    def _get_destination_profiles(
+        self,
+        is_values_required: bool = False,
+    ) -> Dict:
+        """Fetch destination profiles from the Netskope Tenant.
+
+        Iterates over the destinations list endpoint using
+        offset/limit pagination and returns a mapping keyed by
+        profile name. Each value carries the metadata fields
+        required for de-duplication and capacity checks.
+
+        Args:
+            is_values_required (bool): When True request the
+                profile ``values`` as well (needed to skip values
+                that are already present). Defaults to False.
+
+        Returns:
+            Dict: Mapping of profile name to profile metadata
+                (id, name, type, values_count, description[, values]).
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = f"{tenant_name}{URLS.get('V2_DESTINATION_PROFILE')}"
+        profiles = {}
+        offset = 0
+        limit = 100
+        logger_msg = "fetching destination profiles from the Netskope Tenant"
+        self.logger.debug(
+            f"{self.log_prefix}: {logger_msg.capitalize()}."
+        )
+        try:
+            # Drive the loop off the page size rather than a returned
+            # total: stop once a page returns fewer than ``limit``
+            # items and advance the offset by the number actually
+            # returned, so a missing/incorrect total cannot cause an
+            # early stop or an infinite loop.
+            while True:
+                params = {
+                    "fields": (
+                        "id,name,type,values_count,description"
+                        + (",values" if is_values_required else "")
+                    ),
+                    "offset": offset,
+                    "limit": limit,
+                }
+                response = self.netskope_helper._api_call_helper(
+                    url=url,
+                    method="get",
+                    error_codes=["CRE_1063", "CRE_1064"],
+                    headers=headers,
+                    params=params,
+                    proxies=self.proxy,
+                    message=f"Error occurred while {logger_msg}",
+                    logger_msg=logger_msg,
+                )
+                elements = response.get("elements", [])
+                for profile in elements:
+                    profiles[profile.get("name", "")] = profile
+                if len(elements) < limit:
+                    break
+                offset += len(elements)
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+        self.logger.info(
+            f"{self.log_prefix}: Successfully fetched "
+            f"{len(profiles)} destination profile(s)."
+        )
+        return profiles
+
+    def _deploy_destination_profile(self, ids: list) -> bool:
+        """Apply pending changes for the given destination profiles.
+
+        Calls the destinations deploy endpoint so that profiles
+        carrying undeployed (pending) changes become editable
+        again before values are appended.
+
+        Args:
+            ids (list): Destination profile ids to deploy.
+
+        Returns:
+            bool: True when every requested id was applied,
+                False otherwise.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = f"{tenant_name}{URLS.get('V2_DESTINATION_PROFILE_DEPLOY')}"
+        payload = {"ids": ids}
+        logger_msg = (
+            "applying pending changes for destination "
+            f"profile(s) {ids}"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {logger_msg.capitalize()}."
+        )
+        try:
+            response = self.netskope_helper._api_call_helper(
+                url=url,
+                method="post",
+                error_codes=["CRE_1067", "CRE_1068"],
+                headers=headers,
+                json=payload,
+                proxies=self.proxy,
+                message=f"Error occurred while {logger_msg}",
+                logger_msg=logger_msg,
+                is_handle_error_required=False,
+            )
+            if response.status_code not in [200, 201]:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Error occurred while "
+                        f"{logger_msg}. Received exit code "
+                        f"{response.status_code}."
+                    ),
+                    details=str(response.text),
+                )
+                return False
+            deploy_json = handle_status_code(
+                response,
+                error_code="CRE_1068",
+                custom_message=f"Error occurred while {logger_msg}",
+                plugin=self.log_prefix,
+                notify=False,
+                log=True,
+            )
+            applied = []
+            if isinstance(deploy_json, dict):
+                applied = deploy_json.get("applied", [])
+            success = all(str(i) in [str(a) for a in applied] for i in ids)
+            if not success:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Pending changes were not "
+                        f"applied for all destination profile(s) {ids}."
+                    ),
+                    details=repr(deploy_json),
+                )
+            return success
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+
+    def _push_destination_profile(
+        self,
+        destination_values: list,
+        existing_profile_name: str,
+        new_profile_name: str,
+        new_profile_description: str,
+        match_type: str,
+        apply_pending_changes: str = "No",
+        operation: str = "append",
+        exact_total_limit: Optional[int] = None,
+    ) -> int:
+        """Create or update values on a Netskope destination profile.
+
+        When ``existing_profile_name`` is ``"create"`` a new profile
+        is created with the resolved values. Otherwise, for an
+        ``append`` operation the values are added (PATCH on the values
+        endpoint) to the matching profile, skipping any value already
+        present; for a ``replace`` operation the whole value list is
+        overwritten in a single PATCH on the profile id endpoint.
+        Capacity limits are respected best-effort by trimming overflow
+        before the request, while still relying on the API to reject
+        anything it cannot accept. A 409 pending-changes response
+        triggers a deploy + retry only when ``apply_pending_changes``
+        is ``"Yes"``; otherwise it is logged and skipped.
+
+        Args:
+            destination_values (list): Resolved, de-duplicated values
+                to add to the profile.
+            existing_profile_name (str): Selected profile name, or the
+                literal ``"create"`` to create a new profile.
+            new_profile_name (str): Name to use when creating a profile.
+            new_profile_description (str): Description for a new profile.
+            match_type (str): Match type for a new profile
+                (insensitive/sensitive/regex).
+            apply_pending_changes (str): ``"Yes"`` to auto-deploy
+                pending changes on a 409, else ``"No"``.
+            operation (str): ``append`` to keep the existing values and
+                add to them, ``replace`` to overwrite the profile with
+                the provided values.
+            exact_total_limit (Optional[int]): Tenant-wide exact-match
+                value limit from the action parameter; ``None`` falls
+                back to the default constant.
+
+        Returns:
+            tuple: ``(shared_count, not_applied)`` where ``shared_count``
+                is the count of values successfully shared to the profile
+                and ``not_applied`` is the list of values that failed or
+                were skipped (capacity overflow or a failed batch). Used
+                by the bulk caller to attribute unshared values back to
+                their originating action ids.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        values = [v for v in destination_values if v]
+        if not values:
+            self.logger.info(
+                f"{self.log_prefix}: No network targets to share "
+                "after removing empty entries. Skipping action execution."
+            )
+            return 0, []
+        try:
+            existing_profiles = self._get_destination_profiles(
+                is_values_required=True
+            )
+            if existing_profile_name == "create":
+                # Re-running the action with the same parameters would
+                # otherwise attempt to create a duplicate profile, which
+                # the API rejects with an "already exists" error. If a
+                # profile with the requested name already exists, share
+                # the values to it instead of creating a new one.
+                if new_profile_name not in existing_profiles:
+                    return self._create_destination_profile(
+                        tenant_name=tenant_name,
+                        headers=headers,
+                        profile_name=new_profile_name,
+                        description=new_profile_description,
+                        match_type=match_type,
+                        values=values,
+                        existing_profiles=existing_profiles,
+                        exact_total_limit=exact_total_limit,
+                    )
+                self.logger.info(
+                    f"{self.log_prefix}: Destination profile "
+                    f"'{new_profile_name}' already exists on the "
+                    "Netskope Tenant; adding values to the existing "
+                    "profile instead of creating a new one."
+                )
+                target_profile = existing_profiles.get(new_profile_name)
+            else:
+                target_profile = existing_profiles.get(
+                    existing_profile_name
+                )
+                if not target_profile:
+                    error_message = (
+                        f"Destination profile '{existing_profile_name}' "
+                        "could not be found on the Netskope Tenant."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {error_message}",
+                        resolution=(
+                            "Verify the destination profile still exists "
+                            "on the Netskope Tenant and re-run the "
+                            "action."
+                        ),
+                    )
+                    raise NetskopeException(error_message)
+                self.logger.info(
+                    f"{self.log_prefix}: Found destination "
+                    f"profile '{existing_profile_name}' on "
+                    "the Netskope Tenant."
+                )
+            if operation == "replace":
+                return self._replace_destination_profile_values(
+                    tenant_name=tenant_name,
+                    headers=headers,
+                    profile=target_profile,
+                    values=values,
+                    new_profile_description=new_profile_description,
+                    match_type=match_type,
+                    existing_profiles=existing_profiles,
+                    apply_pending_changes=apply_pending_changes,
+                    exact_total_limit=exact_total_limit,
+                )
+            return self._append_destination_profile_values(
+                tenant_name=tenant_name,
+                headers=headers,
+                profile=target_profile,
+                values=values,
+                new_profile_description=new_profile_description,
+                match_type=match_type,
+                existing_profiles=existing_profiles,
+                apply_pending_changes=apply_pending_changes,
+                exact_total_limit=exact_total_limit,
+            )
+        except NetskopeException:
+            raise
+        except Exception as err:
+            profile_name = (
+                new_profile_name
+                if existing_profile_name == "create"
+                else existing_profile_name
+            )
+            error_message = (
+                "Unexpected error occurred while adding Network Targets"
+                f" to destination profile '{profile_name}'."
+            )
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+
+    def _create_destination_profile(
+        self,
+        tenant_name: str,
+        headers: dict,
+        profile_name: str,
+        description: str,
+        match_type: str,
+        values: list,
+        existing_profiles: Dict,
+        exact_total_limit: Optional[int] = None,
+    ) -> int:
+        """Create a new destination profile with the given values.
+
+        Trims the value list to the available capacity for the
+        requested match type before issuing the create request, then
+        relies on the API to reject anything it still cannot accept.
+
+        Args:
+            tenant_name (str): Netskope tenant base URL.
+            headers (dict): Request headers including the API token.
+            profile_name (str): Name of the profile to create.
+            description (str): Description for the new profile.
+            match_type (str): Match type for the new profile.
+            values (list): De-duplicated values to add.
+            existing_profiles (Dict): Existing profiles used for the
+                capacity computation.
+            exact_total_limit (Optional[int]): Tenant-wide exact-match
+                value limit override; ``None`` uses the default
+                constant.
+
+        Returns:
+            tuple: ``(shared_count, not_applied)`` where ``shared_count``
+                is the count of values successfully shared and
+                ``not_applied`` is the list of values dropped because of
+                capacity limits.
+        """
+        max_shareable, limit_label = self.netskope_helper._destination_profile_capacity(
+            existing_profiles=existing_profiles,
+            target_profile_name="",
+            match_type=match_type,
+            requested_count=len(values),
+            exact_total_limit=exact_total_limit,
+        )
+        if max_shareable <= 0:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: The destination profile "
+                    f"capacity for match type '{match_type}' is "
+                    f"exhausted on the Netskope Tenant ({limit_label} "
+                    "has been reached). Skipping creation of profile "
+                    f"'{profile_name}'."
+                ),
+                resolution=(
+                    "Remove unused values or profiles on the Netskope "
+                    "Tenant to free up capacity, then re-run the action."
+                ),
+            )
+            return 0, list(values)
+        bounded_values = values[:max_shareable]
+        capacity_overflow_values = values[max_shareable:]
+        capacity_overflow = len(capacity_overflow_values)
+        # The create POST body is also bound by the destination profile
+        # API payload limit, so only the first chunk that fits is sent on
+        # create; the remainder is appended on the values endpoint after
+        # the profile id is known.
+        budget = (
+            DESTINATION_PROFILE_PAYLOAD_LIMIT
+            - DESTINATION_PROFILE_PAYLOAD_SAFETY_BUFFER
+        )
+        base_overhead = len(
+            json.dumps(
+                {
+                    "name": profile_name,
+                    "description": description,
+                    "type": match_type,
+                    "values": [],
+                }
+            ).encode("utf-8")
+        )
+        post_chunk, post_overflow = (
+            self.netskope_helper._split_values_within_budget(
+                bounded_values, base_overhead, budget
+            )
+        )
+        # A single value can never realistically exceed the budget; if
+        # the metadata pushed the first value just over, still send it so
+        # the profile is created with at least one value.
+        if not post_chunk and bounded_values:
+            post_chunk = [bounded_values[0]]
+            post_overflow = bounded_values[1:]
+        payload = {
+            "name": profile_name,
+            "description": description,
+            "type": match_type,
+            "values": post_chunk,
+        }
+        url = f"{tenant_name}{URLS.get('V2_DESTINATION_PROFILE')}"
+        logger_msg = (
+            f"creating destination profile '{profile_name}' on the "
+            "Netskope Tenant"
+        )
+        self.logger.info(
+            f"{self.log_prefix}: Creating destination profile "
+            f"'{profile_name}' with {len(bounded_values)} "
+            "provided network target(s) on the Netskope "
+            "Tenant."
+        )
+        response = self.netskope_helper._api_call_helper(
+            url=url,
+            method="post",
+            error_codes=["CRE_1065", "CRE_1066"],
+            headers=headers,
+            json=payload,
+            proxies=self.proxy,
+            message=f"Error occurred while {logger_msg}",
+            logger_msg=logger_msg,
+            is_handle_error_required=False,
+        )
+        if response.status_code not in [200, 201]:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} Received "
+                    f"exit code {response.status_code}."
+                ),
+                details=str(response.text),
+                resolution=(
+                    "Verify the profile name is unique and the values "
+                    "are valid for the selected match type, then "
+                    "re-run the action."
+                ),
+            )
+            raise NetskopeException(error_message)
+        handle_status_code(
+            response,
+            error_code="CRE_1066",
+            custom_message=f"Error occurred while {logger_msg}",
+            plugin=self.log_prefix,
+            notify=False,
+            log=True,
+        )
+        # Append the values that did not fit the create POST (if any) to
+        # the freshly created profile via the values endpoint.
+        not_applied = list(capacity_overflow_values)
+        applied_count = len(post_chunk)
+        if post_overflow:
+            profile_id = ""
+            try:
+                profile_id = (response.json() or {}).get("id", "")
+            except Exception:
+                profile_id = ""
+            if not profile_id:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Could not determine the id "
+                        f"of the newly created destination profile "
+                        f"'{profile_name}', so {len(post_overflow)} "
+                        "value(s) that did not fit the create request "
+                        "could not be added."
+                    ),
+                    resolution=(
+                        "Re-run the action to add the remaining values "
+                        "to the now-existing destination profile."
+                    ),
+                )
+                not_applied.extend(post_overflow)
+            else:
+                failed_idx = self._append_destination_value_batches(
+                    tenant_name=tenant_name,
+                    headers=headers,
+                    profile_id=profile_id,
+                    profile_name=profile_name,
+                    values=post_overflow,
+                    apply_pending_changes="No",
+                )
+                applied_count += len(post_overflow) - len(failed_idx)
+                not_applied.extend(
+                    post_overflow[i] for i in sorted(failed_idx)
+                )
+        overflow_msg = ""
+        if capacity_overflow:
+            overflow_msg = (
+                f" Skipped {capacity_overflow} value(s) that exceeded "
+                f"{limit_label} on the Netskope Tenant."
+            )
+        self.logger.info(
+            f"{self.log_prefix}: Successfully created destination "
+            f"profile '{profile_name}' with {applied_count} "
+            f"value(s).{overflow_msg}"
+        )
+        return applied_count, not_applied
+
+    def _append_destination_profile_values(
+        self,
+        tenant_name: str,
+        headers: dict,
+        profile: dict,
+        values: list,
+        new_profile_description: str,
+        match_type: str,
+        existing_profiles: Dict,
+        apply_pending_changes: str,
+        exact_total_limit: Optional[int] = None,
+    ) -> int:
+        """Append values to an existing destination profile.
+
+        The whole value list (the profile's current values plus the
+        provided values) is sent in a single PATCH on the profile id
+        endpoint, together with the desired match ``type`` (always sent,
+        required by this endpoint) and ``description`` (sent only when it
+        differs from the fetched profile). Values already present on the
+        profile are **not** removed from the provided set: a destination
+        profile accepts duplicate values regardless of match type, so a
+        provided value already on the profile is added again. The
+        provided values are trimmed to the available capacity before the
+        request. A 409 pending-changes response is deployed and the PATCH
+        retried once when ``apply_pending_changes`` is ``"Yes"``;
+        otherwise it is logged and skipped.
+
+        Args:
+            tenant_name (str): Netskope tenant base URL.
+            headers (dict): Request headers including the API token.
+            profile (dict): Target profile metadata (id, name, type,
+                description, values[, values_count]).
+            values (list): De-duplicated values to add to the profile.
+            new_profile_description (str): Desired description; sent only
+                if it differs from the existing one.
+            match_type (str): Desired match type; always sent as it is
+                required by the endpoint.
+            existing_profiles (Dict): Existing profiles used for the
+                capacity computation.
+            apply_pending_changes (str): ``"Yes"`` to auto-deploy on a
+                409, else ``"No"``.
+            exact_total_limit (Optional[int]): Tenant-wide exact-match
+                value limit override; ``None`` uses the default
+                constant.
+
+        Returns:
+            tuple: ``(shared_count, not_applied)`` where ``shared_count``
+                is the count of values successfully added and
+                ``not_applied`` is the list of values dropped because of
+                capacity limits, or the whole provided set when the PATCH
+                itself is skipped/failed.
+        """
+        profile_id = profile.get("id", "")
+        profile_name = profile.get("name", "")
+        existing_type = profile.get("type", "")
+        existing_description = profile.get("description", "")
+        existing_values = list(profile.get("values", []) or [])
+        # For an append that also switches the type to regex, the by-id
+        # PATCH must re-send all existing values with the new type. If
+        # the existing value count alone exceeds the regex total limit,
+        # the PATCH will time out regardless of how many new values are
+        # added — short-circuit before making any API call.
+        if (
+            match_type == "regex"
+            and existing_type != "regex"
+            and len(existing_values)
+            > DESTINATION_PROFILE_REGEX_TOTAL_LIMIT
+        ):
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Cannot change the "
+                    f"match type of destination profile "
+                    f"'{profile_name}' to 'regex' — the "
+                    f"profile already holds "
+                    f"{len(existing_values)} value(s), which "
+                    "exceeds the regex total limit of "
+                    f"{DESTINATION_PROFILE_REGEX_TOTAL_LIMIT}."
+                    " Skipping action execution.."
+                ),
+                resolution=(
+                    "Reduce the profile's values to below "
+                    f"{DESTINATION_PROFILE_REGEX_TOTAL_LIMIT}"
+                    " before changing its match type to "
+                    "'regex', then re-run the action."
+                ),
+            )
+            return 0, list(values)
+        # The existing values stay on the profile, so the capacity
+        # baseline keeps the profile's current usage and only the newly
+        # provided values count as requested. Use match_type (the desired
+        # type) so that a type switch (e.g. exact → regex) is checked
+        # against the correct bucket; using existing_type would silently
+        # pass new values that the API will reject.
+        max_shareable, limit_label = self.netskope_helper._destination_profile_capacity(
+            existing_profiles=existing_profiles,
+            target_profile_name=profile_name,
+            match_type=match_type,
+            requested_count=len(values),
+            exact_total_limit=exact_total_limit,
+        )
+        type_changed = bool(match_type) and match_type != existing_type
+        desc_changed = bool(new_profile_description) and (
+            new_profile_description != existing_description
+        )
+        if max_shareable > 0:
+            bounded_new = values[:max_shareable]
+            capacity_overflow_values = values[max_shareable:]
+            if capacity_overflow_values:
+                self.logger.info(
+                    f"{self.log_prefix}: "
+                    f"{len(capacity_overflow_values)} of "
+                    f"{len(values)} provided network target(s)"
+                    f" exceed the capacity for destination "
+                    f"profile '{profile_name}' ({limit_label})"
+                    f"; only {len(bounded_new)} will be "
+                    "applied."
+                )
+        else:
+            bounded_new = []
+            capacity_overflow_values = list(values)
+        # Nothing new fits and the match type/description are unchanged:
+        # there is nothing to send.
+        if not bounded_new and not type_changed and not desc_changed:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: The destination profile "
+                    f"capacity for '{profile_name}' (match type "
+                    f"'{match_type}') is exhausted on the Netskope "
+                    f"Tenant ({limit_label} has been reached). "
+                    "Skipping adding values."
+                ),
+                resolution=(
+                    "Remove unused values or profiles on the Netskope "
+                    "Tenant to free up capacity, then re-run the action."
+                ),
+            )
+            return 0, list(values)
+        # The match type is always sent; the description only when it
+        # differs from the fetched profile.
+        metadata_body = {"type": match_type}
+        if desc_changed:
+            metadata_body["description"] = new_profile_description
+        # The existing values are kept on the profile, so they lead the
+        # value set the profile must end up holding; the provided
+        # (capacity-bounded) values follow and are the only ones
+        # attributed back to action ids.
+        return self._write_destination_profile_values(
+            tenant_name=tenant_name,
+            headers=headers,
+            profile_id=profile_id,
+            profile_name=profile_name,
+            metadata_body=metadata_body,
+            existing_values=existing_values,
+            new_values=bounded_new,
+            capacity_overflow_values=capacity_overflow_values,
+            apply_pending_changes=apply_pending_changes,
+            action_phrase="adding values to destination profile",
+            success_verb="added values to",
+            limit_label=limit_label,
+        )
+
+    def _replace_destination_profile_values(
+        self,
+        tenant_name: str,
+        headers: dict,
+        profile: dict,
+        values: list,
+        new_profile_description: str,
+        match_type: str,
+        existing_profiles: Dict,
+        apply_pending_changes: str,
+        exact_total_limit: Optional[int] = None,
+    ) -> int:
+        """Replace all values on an existing destination profile.
+
+        Overwrites the profile's value list in a single PATCH on the
+        profile id endpoint, which is far cheaper than removing the
+        existing values in capped batches. ``type`` is always sent (it
+        is required by this endpoint); ``description`` is included only
+        when it differs from the profile fetched from the API. The new
+        value set is trimmed to the
+        available capacity (the profile's current values are freed by
+        the replace). A 409 pending-changes response is deployed and
+        the PATCH retried once when ``apply_pending_changes`` is
+        ``"Yes"``; otherwise it is logged and skipped.
+
+        Args:
+            tenant_name (str): Netskope tenant base URL.
+            headers (dict): Request headers including the API token.
+            profile (dict): Target profile metadata (id, name, type,
+                description).
+            values (list): De-duplicated values to set on the profile.
+            new_profile_description (str): Desired description; sent
+                only if it differs from the existing one.
+            match_type (str): Desired match type; always sent as it is
+                required by the endpoint.
+            existing_profiles (Dict): Existing profiles used for the
+                capacity computation.
+            apply_pending_changes (str): ``"Yes"`` to auto-deploy on a
+                409, else ``"No"``.
+            exact_total_limit (Optional[int]): Tenant-wide exact-match
+                value limit override; ``None`` uses the default
+                constant.
+
+        Returns:
+            tuple: ``(shared_count, not_applied)`` where ``shared_count``
+                is the count of values the profile was replaced with and
+                ``not_applied`` is the list of values that could not be
+                applied (capacity overflow, or the whole value set when
+                the replace request itself is skipped/failed).
+        """
+        profile_id = profile.get("id", "")
+        profile_name = profile.get("name", "")
+        existing_type = profile.get("type", "")
+        existing_description = profile.get("description", "")
+        # Replacing frees the profile's current values, so treat its
+        # usage as zero when checking capacity for the new value set.
+        # Use match_type (the desired type after the replace), not
+        # existing_type: if the replace also changes the type bucket
+        # (exact ↔ regex), the capacity limits differ and using the old
+        # type would silently pass a value set that the API rejects.
+        capacity_profiles = dict(existing_profiles)
+        target_copy = dict(capacity_profiles.get(profile_name, {}))
+        target_copy["values_count"] = 0
+        capacity_profiles[profile_name] = target_copy
+        max_shareable, limit_label = self.netskope_helper._destination_profile_capacity(
+            existing_profiles=capacity_profiles,
+            target_profile_name=profile_name,
+            match_type=match_type,
+            requested_count=len(values),
+            exact_total_limit=exact_total_limit,
+        )
+        if max_shareable <= 0:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: The destination profile "
+                    f"capacity for '{profile_name}' (match type "
+                    f"'{match_type}') is exhausted on the Netskope "
+                    f"Tenant ({limit_label} has been reached). "
+                    "Skipping value replacement."
+                ),
+                resolution=(
+                    "Remove unused values or profiles on the Netskope "
+                    "Tenant to free up capacity, then re-run the action."
+                ),
+            )
+            return 0, list(values)
+        bounded_values = values[:max_shareable]
+        capacity_overflow_values = values[max_shareable:]
+        if capacity_overflow_values:
+            self.logger.info(
+                f"{self.log_prefix}: "
+                f"{len(capacity_overflow_values)} of "
+                f"{len(values)} provided network target(s) "
+                f"exceed the capacity for destination profile"
+                f" '{profile_name}' ({limit_label}); only "
+                f"{len(bounded_values)} will be applied."
+            )
+        # The match type is always sent; the description only when it
+        # differs from the fetched profile.
+        metadata_body = {"type": match_type}
+        if (
+            new_profile_description
+            and new_profile_description != existing_description
+        ):
+            metadata_body["description"] = new_profile_description
+        # Replace discards the profile's current values, so there are no
+        # existing values to preserve; the whole (capacity-bounded)
+        # provided set is what the profile must end up holding.
+        return self._write_destination_profile_values(
+            tenant_name=tenant_name,
+            headers=headers,
+            profile_id=profile_id,
+            profile_name=profile_name,
+            metadata_body=metadata_body,
+            existing_values=[],
+            new_values=bounded_values,
+            capacity_overflow_values=capacity_overflow_values,
+            apply_pending_changes=apply_pending_changes,
+            action_phrase="replacing the values of destination profile",
+            success_verb="replaced the values of",
+            limit_label=limit_label,
+        )
+
+    def _write_destination_profile_values(
+        self,
+        tenant_name: str,
+        headers: dict,
+        profile_id: str,
+        profile_name: str,
+        metadata_body: dict,
+        existing_values: list,
+        new_values: list,
+        capacity_overflow_values: list,
+        apply_pending_changes: str,
+        action_phrase: str,
+        success_verb: str,
+        limit_label: str,
+    ) -> tuple:
+        """Write a profile's value set, splitting at the payload budget.
+
+        Shared by the append and replace operations. The value set the
+        profile must end up holding is ``existing_values + new_values``
+        (``existing_values`` is empty for replace). The leading chunk
+        that fits the destination profile by-id PATCH payload budget —
+        together with the ``metadata_body`` (``type`` always,
+        ``description`` when changed) — is written with a single by-id
+        PATCH (which **replaces** the value list); whatever did not fit is
+        then added in batches of up to
+        ``DESTINATION_PROFILE_VALUES_PER_APPEND`` (10) values on the values
+        endpoint (``op: append``, which leaves the already-written values
+        in place). When the whole set fits the budget this collapses to a
+        single by-id PATCH.
+
+        Only the provided (``new_values``) values are attributed back to
+        action ids: a provided value is applied when it landed in the
+        PATCH chunk or in a batch that appended successfully. Existing
+        values that are re-sent only to preserve them are not attributed
+        (see the metadata-update transient-state risk in the workflow
+        doc).
+
+        Args:
+            tenant_name (str): Netskope tenant base URL.
+            headers (dict): Request headers including the API token.
+            profile_id (str): Id of the target profile.
+            profile_name (str): Name of the target profile (logging).
+            metadata_body (dict): ``type`` plus an optional
+                ``description`` to apply via the by-id PATCH.
+            existing_values (list): Values already on the profile that
+                must be preserved (empty for replace).
+            new_values (list): Capacity-bounded provided values; the only
+                ones attributed back to action ids.
+            capacity_overflow_values (list): Provided values dropped for
+                capacity before this call; reported as not applied.
+            apply_pending_changes (str): ``"Yes"`` to auto-deploy on a
+                409, else ``"No"``.
+            action_phrase (str): Present-participle phrase for in-progress
+                / error logs, e.g. ``"adding values to destination
+                profile"``.
+            success_verb (str): Past-tense verb for the success summary,
+                e.g. ``"added values to"`` / ``"replaced the values of"``.
+            limit_label (str): Human-readable capacity limit description
+                used in the capacity-overflow part of the summary.
+
+        Returns:
+            tuple: ``(applied_count, not_applied)`` where ``applied_count``
+                is the number of provided values written and
+                ``not_applied`` is the list of provided values that could
+                not be written (capacity overflow, plus any payload batch
+                that was skipped/failed, or the whole provided set when
+                the by-id PATCH itself is skipped/failed).
+        """
+        budget = (
+            DESTINATION_PROFILE_PAYLOAD_LIMIT
+            - DESTINATION_PROFILE_PAYLOAD_SAFETY_BUFFER
+        )
+        combined = list(existing_values) + list(new_values)
+        new_offset = len(existing_values)
+        # The by-id PATCH body carries the metadata, so the first chunk
+        # must fit within the budget once the metadata overhead is
+        # accounted for.
+        patch_overhead = len(
+            json.dumps({**metadata_body, "values": []}).encode("utf-8")
+        )
+        patch_chunk, overflow = (
+            self.netskope_helper._split_values_within_budget(
+                combined, patch_overhead, budget
+            )
+        )
+        # A single value can never realistically exceed the budget; if
+        # the metadata pushed the first value just over, still send it in
+        # the PATCH (the API rejects a values-less PATCH).
+        if not patch_chunk and combined:
+            patch_chunk = [combined[0]]
+            overflow = combined[1:]
+        by_id_path = URLS.get(
+            "V2_DESTINATION_PROFILE_BY_ID"
+        ).format(profile_id)
+        by_id_url = f"{tenant_name}{by_id_path}"
+        patch_logger_msg = f"{action_phrase} '{profile_name}'"
+        if action_phrase.startswith("adding"):
+            self.logger.info(
+                f"{self.log_prefix}: Appending "
+                f"{len(new_values)} provided network "
+                f"target(s) to destination profile "
+                f"'{profile_name}'."
+            )
+        else:
+            self.logger.info(
+                f"{self.log_prefix}: Replacing the values "
+                f"of destination profile '{profile_name}' "
+                f"with {len(new_values)} provided network "
+                "target(s)."
+            )
+        if not self._send_destination_request(
+            url=by_id_url,
+            headers=headers,
+            method="patch",
+            body={**metadata_body, "values": patch_chunk},
+            profile_id=profile_id,
+            profile_name=profile_name,
+            apply_pending_changes=apply_pending_changes,
+            logger_msg=patch_logger_msg,
+        ):
+            # The by-id PATCH itself was skipped or failed, so nothing was
+            # written: every provided value is reported not applied.
+            return 0, list(capacity_overflow_values) + list(new_values)
+        # Append whatever did not fit the PATCH on the values endpoint.
+        failed_overflow_idx = set()
+        if overflow:
+            self.logger.info(
+                f"{self.log_prefix}: Payload limit (9 MB) reached for "
+                f"destination profile '{profile_name}' API call. Adding "
+                f"{len(patch_chunk)} or the {len(combined)} values to the "
+                "destinaton Profile in the initial API call. The remaining "
+                f"{len(overflow)} value(s) will be added via the append "
+                "values endpoint in batches of "
+                f"{DESTINATION_PROFILE_VALUES_PER_APPEND}."
+            )
+            failed_overflow_idx = self._append_destination_value_batches(
+                tenant_name=tenant_name,
+                headers=headers,
+                profile_id=profile_id,
+                profile_name=profile_name,
+                values=overflow,
+                apply_pending_changes=apply_pending_changes,
+            )
+        # Attribute applied vs not-applied for the provided values only.
+        patch_count = len(patch_chunk)
+        not_applied_new = []
+        for j, value in enumerate(new_values):
+            combined_index = new_offset + j
+            if combined_index < patch_count:
+                # Written by the by-id PATCH.
+                continue
+            if (combined_index - patch_count) in failed_overflow_idx:
+                not_applied_new.append(value)
+        applied_count = len(new_values) - len(not_applied_new)
+        not_applied = list(capacity_overflow_values) + not_applied_new
+        overflow_msg = ""
+        if capacity_overflow_values:
+            overflow_msg = (
+                f" Skipped {len(capacity_overflow_values)} value(s) that "
+                f"exceeded {limit_label} on the Netskope Tenant."
+            )
+        payload_skip_msg = ""
+        if not_applied_new:
+            payload_skip_msg = (
+                f" Could not add {len(not_applied_new)} value(s) to the "
+                "destination profile; the append request was skipped or "
+                "failed."
+            )
+        self.logger.info(
+            f"{self.log_prefix}: Successfully {success_verb} destination "
+            f"profile '{profile_name}' ({applied_count} provided "
+            f"value(s) applied).{overflow_msg}{payload_skip_msg}"
+        )
+        return applied_count, not_applied
+
+    def _append_destination_value_batches(
+        self,
+        tenant_name: str,
+        headers: dict,
+        profile_id: str,
+        profile_name: str,
+        values: list,
+        apply_pending_changes: str,
+    ) -> set:
+        """Append values to a profile via the values endpoint in batches.
+
+        The values endpoint accepts at most
+        ``DESTINATION_PROFILE_VALUES_PER_APPEND`` (10) values per call, so
+        ``values`` is split into batches of that many and each batch is
+        appended with a ``PATCH`` to the values endpoint
+        (``{"operation": {"op": "append", "values": [...]}}``), which
+        leaves the profile's existing values in place. (The payload size
+        budget applies only to the by-id PATCH / create POST that carry
+        the match type and description, not to this append endpoint, which
+        is bounded by a value count.) Each batch reuses the shared 409
+        pending-changes deploy + retry handling. Best effort: a batch that
+        is skipped or fails is recorded and the remaining batches are
+        still attempted.
+
+        Args:
+            tenant_name (str): Netskope tenant base URL.
+            headers (dict): Request headers including the API token.
+            profile_id (str): Id of the target profile.
+            profile_name (str): Name of the target profile (logging).
+            values (list): Values to append, in order.
+            apply_pending_changes (str): ``"Yes"`` to auto-deploy on a
+                409, else ``"No"``.
+
+        Returns:
+            set: Indices (into ``values``) whose batch was skipped or
+                failed to append; empty when every batch succeeded.
+        """
+        values_path = URLS.get(
+            "V2_DESTINATION_PROFILE_VALUES"
+        ).format(profile_id)
+        values_url = f"{tenant_name}{values_path}"
+        batch_size = DESTINATION_PROFILE_VALUES_PER_APPEND
+        total_batches = (len(values) + batch_size - 1) // batch_size
+        failed_idx = set()
+        for batch_index, start in enumerate(
+            range(0, len(values), batch_size), start=1
+        ):
+            batch = values[start:start + batch_size]
+            logger_msg = (
+                f"appending values to destination profile "
+                f"'{profile_name}' (batch {batch_index} of "
+                f"{total_batches})"
+            )
+            try:
+                self.logger.info(
+                    f"{self.log_prefix}: Appending "
+                    f"{len(batch)} value(s) to destination "
+                    f"profile '{profile_name}' "
+                    f"(batch {batch_index} of "
+                    f"{total_batches})."
+                )
+                if not self._send_destination_request(
+                    url=values_url,
+                    headers=headers,
+                    method="patch",
+                    body={
+                        "operation": {
+                            "op": "append",
+                            "values": batch,
+                        }
+                    },
+                    profile_id=profile_id,
+                    profile_name=profile_name,
+                    apply_pending_changes=apply_pending_changes,
+                    logger_msg=logger_msg,
+                ):
+                    failed_idx.update(
+                        range(start, start + len(batch))
+                    )
+                    continue
+                self.logger.info(
+                    f"{self.log_prefix}: Successfully "
+                    f"appended {len(batch)} value(s) to "
+                    f"destination profile '{profile_name}'"
+                    f" (batch {batch_index} of "
+                    f"{total_batches})."
+                )
+            except Exception as err:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Unexpected "
+                        "error while appending values to "
+                        f"destination profile '{profile_name}'"
+                        f" (batch {batch_index} of "
+                        f"{total_batches}). Error: {err}"
+                    ),
+                    details=re.sub(
+                        r"token=([0-9a-zA-Z]*)",
+                        "token=********&",
+                        traceback.format_exc(),
+                    ),
+                    resolution=(
+                        "Re-run the action to retry the "
+                        "failed values."
+                    ),
+                )
+                failed_idx.update(
+                    range(start, start + len(batch))
+                )
+        return failed_idx
+
+    def _send_destination_request(
+        self,
+        url: str,
+        headers: dict,
+        method: str,
+        body: dict,
+        profile_id: str,
+        profile_name: str,
+        apply_pending_changes: str,
+        logger_msg: str,
+    ) -> bool:
+        """Send a destination profile write, handling pending changes.
+
+        The single request primitive shared by the by-id PATCH and the
+        values-endpoint append. A 409 pending-changes response triggers a
+        deploy + retry once when ``apply_pending_changes`` is ``"Yes"``;
+        otherwise it is logged and skipped.
+
+        Args:
+            url (str): Fully built request URL.
+            headers (dict): Request headers including the API token.
+            method (str): HTTP method (``"patch"``).
+            body (dict): Request body.
+            profile_id (str): Id of the target profile (used for the
+                deploy call on a 409).
+            profile_name (str): Name of the target profile (logging).
+            apply_pending_changes (str): ``"Yes"`` to auto-deploy on a
+                409, else ``"No"``.
+            logger_msg (str): Present-participle phrase for error logs,
+                e.g. ``"adding values to destination profile 'X'"``.
+
+        Returns:
+            bool: ``True`` on a 2xx response, ``False`` when the request
+                is skipped (pending changes not applied) or fails.
+        """
+        for attempt in range(2):
+            response = self.netskope_helper._api_call_helper(
+                url=url,
+                method=method,
+                error_codes=["CRE_1065", "CRE_1066"],
+                headers=headers,
+                json=body,
+                proxies=self.proxy,
+                message=f"Error occurred while {logger_msg}",
+                logger_msg=logger_msg,
+                is_handle_error_required=False,
+            )
+            response_text = (
+                response.text
+                if hasattr(response, "text")
+                else str(response)
+            )
+            if (
+                response.status_code == 409
+                and PENDING_CHANGES_DETECTED in response_text
+            ):
+                if apply_pending_changes == "Yes" and attempt == 0:
+                    self.logger.info(
+                        f"{self.log_prefix}: Pending changes detected "
+                        f"for destination profile '{profile_name}'. "
+                        "Applying pending changes and retrying."
+                    )
+                    if self._deploy_destination_profile([profile_id]):
+                        continue
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: Could not apply "
+                            f"pending changes for destination profile "
+                            f"'{profile_name}'. Skipping action execution."
+                        ),
+                        details=response_text,
+                    )
+                    return False
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Pending changes detected "
+                        f"for destination profile '{profile_name}'. "
+                        "Skipping action execution."
+                    ),
+                    resolution=(
+                        "Set 'Apply Pending Changes' to 'Yes' in the "
+                        "action configuration, or manually apply the "
+                        "pending changes for destination profile "
+                        f"'{profile_name}' from the Netskope Tenant "
+                        "UI, then re-run the action."
+                    ),
+                    details=response_text,
+                )
+                return False
+            if response.status_code not in [200, 201]:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Error occurred while "
+                        f"{logger_msg}. Received exit code "
+                        f"{response.status_code}."
+                    ),
+                    details=response_text,
+                    resolution=(
+                        "Verify the values are valid for the profile "
+                        "match type and the profile capacity is not "
+                        "exceeded, then re-run the action."
+                    ),
+                )
+                return False
+            handle_status_code(
+                response,
+                error_code="CRE_1066",
+                custom_message=f"Error occurred while {logger_msg}",
+                plugin=self.log_prefix,
+                notify=False,
+                log=False,
+            )
+            return True
+        return False
+
+    def _get_dns_profiles(self) -> Dict:
+        """Fetch DNS profiles from the Netskope Tenant.
+
+        Paginates through ``GET /api/v2/profiles/dns`` requesting only
+        the ``id`` and ``name`` fields and returns a mapping of profile
+        name to profile id, suitable for building action dropdowns.
+
+        Returns:
+            Dict: Mapping of DNS profile name to its id.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = f"{tenant_name}{URLS.get('V2_DNS_PROFILE')}"
+        profiles = {}
+        offset = 0
+        limit = 150
+        page_number = 1
+        params = {
+            "offset": offset,
+            "limit": limit,
+            # No space after the comma in the fields query parameter
+            # else the Netskope API returns an error.
+            "fields": "id,name",
+        }
+        logger_msg = "fetching DNS profiles from the Netskope Tenant"
+        self.logger.debug(f"{self.log_prefix}: {logger_msg.capitalize()}.")
+        try:
+            # Drive the loop off the page size: stop once a page returns
+            # fewer than ``limit`` items and advance the offset by the
+            # count actually returned, so a missing total cannot cause an
+            # early stop or an infinite loop.
+            while True:
+                page_msg = f"{logger_msg} for page {page_number}"
+                response = self.netskope_helper._api_call_helper(
+                    url=url,
+                    method="get",
+                    error_codes=["CRE_1063", "CRE_1064"],
+                    headers=headers,
+                    params=params,
+                    proxies=self.proxy,
+                    message=f"Error occurred while {page_msg}",
+                    logger_msg=page_msg,
+                )
+                dns_profiles = response.get("profiles", [])
+                for dns_profile in dns_profiles:
+                    profile_name = dns_profile.get("name", "")
+                    profile_id = dns_profile.get("id")
+                    if profile_name and profile_id:
+                        profiles[profile_name] = profile_id
+                if len(dns_profiles) < limit:
+                    break
+                offset += len(dns_profiles)
+                params["offset"] = offset
+                page_number += 1
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+        self.logger.debug(
+            f"{self.log_prefix}: Successfully fetched {len(profiles)} "
+            "DNS profile(s) from the Netskope Tenant."
+        )
+        return profiles
+
+    def _get_dns_profile_by_name(self, name: str) -> Dict:
+        """Fetch a single DNS profile by its name.
+
+        Args:
+            name (str): Name of the DNS profile to look up.
+
+        Returns:
+            Dict: The full DNS profile object as returned by the API,
+            or an empty dict if no profile with that name exists.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = f"{tenant_name}{URLS.get('V2_DNS_PROFILE')}"
+        params = {
+            "filter": f'name eq "{name}"',
+            "offset": 0,
+            "limit": 150,
+            # No space after the comma in the fields query parameter
+            # else the Netskope API returns an error.
+            "fields": "id,name,description,domain_config,status",
+        }
+        logger_msg = (
+            f"fetching DNS profile '{name}' from the Netskope Tenant"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
+        try:
+            response = self.netskope_helper._api_call_helper(
+                url=url,
+                method="get",
+                error_codes=["CRE_1063", "CRE_1064"],
+                headers=headers,
+                params=params,
+                proxies=self.proxy,
+                message=f"Error occurred while {logger_msg}",
+                logger_msg=logger_msg,
+            )
+            for profile in response.get("profiles", []):
+                if profile.get("name") == name:
+                    return profile
+            return {}
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+
+    def _get_security_categories(self) -> List[str]:
+        """Fetch DNS security categories from the Netskope Tenant.
+
+        Paginates through ``GET /api/v2/profiles/dns/domaincategories``,
+        keeps only categories whose ``category_type`` is ``security``
+        and expands each into ``"<name> (Block)"`` and
+        ``"<name> (Sinkhole)"`` choices for the action dropdown.
+
+        Returns:
+            List[str]: Expanded security category choice strings.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = f"{tenant_name}{URLS.get('V2_DNS_DOMAIN_CATEGORIES')}"
+        categories = []
+        offset = 0
+        limit = 150
+        page_number = 1
+        logger_msg = (
+            "fetching DNS security categories from the Netskope Tenant"
+        )
+        self.logger.debug(f"{self.log_prefix}: {logger_msg.capitalize()}.")
+        try:
+            # Drive the loop off the page size: stop once a page returns
+            # fewer than ``limit`` items and advance the offset by the
+            # count actually returned.
+            while True:
+                page_msg = f"{logger_msg} for page {page_number}"
+                params = {
+                    "offset": offset,
+                    "limit": limit,
+                    "sortby": "name",
+                    "sortorder": "asc",
+                }
+                response = self.netskope_helper._api_call_helper(
+                    url=url,
+                    method="get",
+                    error_codes=["CRE_1063", "CRE_1064"],
+                    headers=headers,
+                    params=params,
+                    proxies=self.proxy,
+                    message=f"Error occurred while {page_msg}",
+                    logger_msg=page_msg,
+                )
+                domain_categories = response.get("domaincategories", [])
+                for category in domain_categories:
+                    category_name = category.get("name", "")
+                    category_type = category.get(
+                        "category_type", ""
+                    ).lower()
+                    if category_name and category_type == "security":
+                        categories.extend(
+                            [
+                                f"{category_name} (Block)",
+                                f"{category_name} (Sinkhole)",
+                            ]
+                        )
+                if len(domain_categories) < limit:
+                    break
+                offset += len(domain_categories)
+                page_number += 1
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+        self.logger.debug(
+            f"{self.log_prefix}: Successfully fetched "
+            f"{len(categories)} DNS security category choice(s) "
+            "from the Netskope Tenant."
+        )
+        return categories
+
+    def _get_record_types(self) -> List[str]:
+        """Fetch DNS record types from the Netskope Tenant.
+
+        Paginates through ``GET /api/v2/profiles/dns/recordtypes`` and
+        returns the list of record type names for the action dropdown.
+
+        Returns:
+            List[str]: List of DNS record type names.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = f"{tenant_name}{URLS.get('V2_DNS_RECORD_TYPES')}"
+        record_types = []
+        offset = 0
+        limit = 150
+        page_number = 1
+        logger_msg = (
+            "fetching DNS record types from the Netskope Tenant"
+        )
+        self.logger.debug(f"{self.log_prefix}: {logger_msg.capitalize()}.")
+        try:
+            # Drive the loop off the page size: stop once a page returns
+            # fewer than ``limit`` items and advance the offset by the
+            # count actually returned.
+            while True:
+                page_msg = f"{logger_msg} for page {page_number}"
+                params = {
+                    "offset": offset,
+                    "limit": limit,
+                    "sortby": "name",
+                    "sortorder": "asc",
+                }
+                response = self.netskope_helper._api_call_helper(
+                    url=url,
+                    method="get",
+                    error_codes=["CRE_1063", "CRE_1064"],
+                    headers=headers,
+                    params=params,
+                    proxies=self.proxy,
+                    message=f"Error occurred while {page_msg}",
+                    logger_msg=page_msg,
+                )
+                elements = response.get("recordtypes", [])
+                for record_type in elements:
+                    record_type_name = record_type.get("name", "")
+                    if record_type_name:
+                        record_types.append(record_type_name)
+                if len(elements) < limit:
+                    break
+                offset += len(elements)
+                page_number += 1
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+        self.logger.debug(
+            f"{self.log_prefix}: Successfully fetched "
+            f"{len(record_types)} DNS record type(s) from the "
+            "Netskope Tenant."
+        )
+        return record_types
+
+    def _parse_security_categories(
+        self, raw_categories: List[str]
+    ) -> List[Dict]:
+        """Parse '<name> (Block|Sinkhole)' strings into payload dicts.
+
+        Args:
+            raw_categories (List[str]): Selected category choice
+                strings of the form ``"<name> (Block)"`` or
+                ``"<name> (Sinkhole)"``.
+
+        Returns:
+            List[Dict]: A list of ``{"name": ..., "action": ...}``
+            dicts, one per input string that matches the expected
+            format. Strings that don't match are skipped silently.
+        """
+        pattern = re.compile(
+            r"^(?P<name>.+?)\s*\((?P<action>Block|Sinkhole)\)$"
+        )
+        parsed: List[Dict] = []
+        for category in raw_categories:
+            match = pattern.match(category)
+            if not match:
+                continue
+            parsed.append(
+                {
+                    "name": match.group("name").strip(),
+                    "action": match.group("action"),
+                }
+            )
+        return parsed
+
+    def _push_dns_profile(
+        self,
+        domains: List[str],
+        existing_profile_name: str,
+        new_profile_name: str,
+        action_type: str,
+        action_params: Dict,
+        operation: str = "append",
+    ) -> int:
+        """Share domains to a DNS profile on the Netskope Tenant.
+
+        When ``existing_profile_name`` is ``"create"`` a new profile
+        is created (POST) carrying the profile config and as many of
+        the resolved ``domains`` as fit under the payload budget. When
+        an existing profile is selected, a minimal-diff PATCH body is
+        built and the new domains are packed into the matching list
+        under the same budget. Domains that are not properly formatted
+        (``REGEX_FOR_DOMAIN``) or exceed the RFC length limits are
+        validated out and reported before sharing; domains dropped
+        because they exceed the ``DNS_PROFILE_PAYLOAD_LIMIT`` are
+        likewise reported and skipped.
+
+        Args:
+            domains (List[str]): Resolved, de-duplicated domain names
+                to share to the profile.
+            existing_profile_name (str): Selected profile name, or the
+                literal ``"create"`` to create a new profile.
+            new_profile_name (str): Name to use when creating a profile.
+            action_type (str): ``add_to_allow_list`` or
+                ``add_to_block_list``.
+            action_params (Dict): Resolved action parameters.
+
+        Returns:
+            tuple: ``(shared_count, not_applied)`` where ``shared_count``
+                is the count of domains successfully shared to the
+                profile and ``not_applied`` is the list of domains that
+                were not applied — those dropped as invalid/over-length
+                and those skipped because the payload size budget was
+                exhausted. Used by the bulk caller to attribute unshared
+                domains back to their originating action ids.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        # The DNS profile endpoint only accepts properly formatted
+        # domains. Since values arrive directly from the action's
+        # Static/Source field (not as typed indicators), validate each
+        # against the domain format regex and the RFC length limits
+        # before sharing; malformed entries are dropped and reported.
+        valid_domains = []
+        invalid_domains = []
+        for domain in domains:
+            if not domain:
+                continue
+            if (
+                re.match(REGEX_FOR_DOMAIN, domain)
+                and self.netskope_helper.is_valid_domain_length(domain)
+            ):
+                valid_domains.append(domain)
+            else:
+                invalid_domains.append(domain)
+        if invalid_domains:
+            self.logger.info(
+                f"{self.log_prefix}: Skipping {len(invalid_domains)} "
+                "value(s) as they were either not domains or were of "
+                "invalid format, and therefore cannot be added to the "
+                "DNS profile."
+            )
+        if not valid_domains:
+            self.logger.info(
+                f"{self.log_prefix}: No valid domains to share to the "
+                "DNS profile. Skipping action execution."
+            )
+            return 0, list(invalid_domains)
+        if action_type == "add_to_allow_list":
+            list_key = "allow_list"
+            list_key_label = "allowlist"
+        elif action_type == "add_to_block_list":
+            list_key = "block_list"
+            list_key_label = "blocklist"
+        else:
+            error_message = (
+                f"Invalid action type '{action_type}'. Valid values "
+                "are 'add_to_allow_list' or 'add_to_block_list'."
+            )
+            self.logger.error(
+                message=f"{self.log_prefix}: {error_message}",
+                resolution=(
+                    "Re-run the action with a valid Action Type "
+                    "selection."
+                ),
+            )
+            raise NetskopeException(error_message)
+        security_categories = self._parse_security_categories(
+            action_params.get("dns_security_categories", [])
+        )
+        try:
+            if existing_profile_name == "create":
+                profile_name = new_profile_name
+                existing_profile = self._get_dns_profile_by_name(
+                    profile_name
+                )
+                # Re-running the action with the same parameters would
+                # otherwise attempt to create a duplicate profile, which
+                # the API rejects with an "already exists" error. If a
+                # profile with the requested name already exists, share
+                # the domains to it instead of creating a new one.
+                if existing_profile:
+                    self.logger.info(
+                        f"{self.log_prefix}: DNS profile "
+                        f"'{profile_name}' already exists on the "
+                        "Netskope Tenant; adding domains to the "
+                        "existing profile instead of creating a new one."
+                    )
+                    body = self.netskope_helper._build_dns_patch_body(
+                        existing_profile=existing_profile,
+                        action_params=action_params,
+                        action_type=action_type,
+                        operation=operation,
+                        security_categories=security_categories,
+                    )
+                    method = "patch"
+                    profile_path = URLS.get(
+                        "V2_DNS_PROFILE_BY_ID"
+                    ).format(existing_profile.get("id"))
+                    url = f"{tenant_name}{profile_path}"
+                    log_action = (
+                        f"updating DNS profile '{profile_name}' on the "
+                        "Netskope Tenant"
+                    )
+                else:
+                    body = self.netskope_helper._build_dns_create_body(
+                        profile_name=profile_name,
+                        action_params=action_params,
+                        action_type=action_type,
+                        security_categories=security_categories,
+                    )
+                    method = "post"
+                    url = f"{tenant_name}{URLS.get('V2_DNS_PROFILE')}"
+                    log_action = (
+                        f"creating DNS profile '{profile_name}' on the "
+                        "Netskope Tenant"
+                    )
+            else:
+                profile_name = existing_profile_name
+                existing_profile = self._get_dns_profile_by_name(
+                    profile_name
+                )
+                if not existing_profile:
+                    error_message = (
+                        f"DNS profile '{profile_name}' could not be "
+                        "found on the Netskope Tenant."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {error_message}",
+                        resolution=(
+                            "Verify the DNS profile still exists on the "
+                            "Netskope Tenant and re-run the action."
+                        ),
+                    )
+                    raise NetskopeException(error_message)
+                body = self.netskope_helper._build_dns_patch_body(
+                    existing_profile=existing_profile,
+                    action_params=action_params,
+                    action_type=action_type,
+                    operation=operation,
+                    security_categories=security_categories,
+                )
+                method = "patch"
+                profile_path = URLS.get(
+                    "V2_DNS_PROFILE_BY_ID"
+                ).format(existing_profile.get("id"))
+                url = f"{tenant_name}{profile_path}"
+                log_action = (
+                    f"updating DNS profile '{profile_name}' on the "
+                    "Netskope Tenant"
+                )
+            budget = (
+                DNS_PROFILE_PAYLOAD_LIMIT
+                - DNS_PROFILE_PAYLOAD_SAFETY_BUFFER
+            )
+            accepted, skipped = self.netskope_helper._pack_domains_within_budget(
+                body=body,
+                list_key=list_key,
+                candidate_domains=valid_domains,
+                budget_bytes=budget,
+            )
+            # In the patch flow, if the packer accepted zero candidates
+            # and the trailing target entry has no domains, drop it so
+            # the patch body never carries a meaningless empty entry.
+            if method == "patch":
+                list_entries = body.get("domain_config", {}).get(
+                    list_key, []
+                )
+                if list_entries and not list_entries[-1].get(
+                    "domain_names"
+                ):
+                    list_entries.pop()
+            if not accepted:
+                self.logger.info(
+                    f"{self.log_prefix}: DNS profile API payload size "
+                    f"limit reached for {list_key_label} before any "
+                    f"domains could be added; skipping all "
+                    f"{len(skipped)} domain(s)."
+                )
+                return 0, list(invalid_domains) + list(skipped)
+            self.logger.info(
+                f"{self.log_prefix}: Out of {len(valid_domains)} "
+                f"domain(s), attempting to share {len(accepted)} "
+                f"domain(s) to {list_key_label} of DNS profile "
+                f"'{profile_name}'. Skipping {len(skipped)} domain(s) "
+                "due to exceeding the DNS profile API payload size "
+                f"limit of {DNS_PROFILE_PAYLOAD_LIMIT / (1024 * 1024)}"
+                " MB."
+            )
+            self.netskope_helper._api_call_helper(
+                url=url,
+                method=method,
+                error_codes=["CRE_1063", "CRE_1064"],
+                headers=headers,
+                json=body,
+                proxies=self.proxy,
+                message=f"Error occurred while {log_action}",
+                logger_msg=log_action,
+            )
+        except NetskopeException:
+            raise
+        except Exception as err:
+            profile_name = (
+                new_profile_name
+                if existing_profile_name == "create"
+                else existing_profile_name
+            )
+            error_message = (
+                "Unexpected error occurred while sharing domains to the DNS "
+                f"profile '{profile_name}'."
+            )
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+        self.logger.info(
+            f"{self.log_prefix}: Successfully added {len(accepted)} "
+            f"domain(s) to {list_key_label} of DNS profile "
+            f"'{profile_name}' on the Netskope Tenant."
+        )
+        return len(accepted), list(invalid_domains) + list(skipped)
+
+    def _get_service_profiles(
+        self,
+        custom_only: bool = True,
+        name: str = None,
+    ) -> Dict:
+        """Fetch service profiles from the Netskope Tenant.
+
+        Paginates through ``GET /api/v2/profiles/serviceobjects``
+        requesting the ``id``, ``name``, ``type``, ``protocols`` and
+        ``description`` fields and returns a mapping of profile name to
+        its full metadata. When ``custom_only`` is True only profiles whose
+        ``type`` equals ``CUSTOM`` (compared case-insensitively, since
+        the list endpoint returns ``CUSTOM``/``PREDEFINED`` while the
+        create endpoint returns lowercase) are kept, because only
+        CUSTOM service profiles are editable. An optional ``name``
+        narrows the listing to a single profile via the API's exact
+        ``name eq`` filter.
+
+        Args:
+            custom_only (bool): When True, keep only ``CUSTOM`` (i.e.
+                editable) service profiles. Defaults to True.
+            name (str): When provided, fetch only the profile with this
+                exact name. Defaults to None.
+
+        Returns:
+            Dict: Mapping of service profile name to its metadata
+                (id, name, type, protocols).
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = f"{tenant_name}{V2_SERVICE_PROFILE}"
+        profiles = {}
+        offset = 0
+        limit = SERVICE_PROFILE_PAGE_SIZE
+        page_number = 1
+        logger_msg = (
+            "fetching service profiles from the Netskope Tenant"
+        )
+        if name:
+            logger_msg = (
+                f"fetching service profile '{name}' from the "
+                "Netskope Tenant"
+            )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
+        try:
+            # Drive the loop off the page size: stop once a page returns
+            # fewer than ``limit`` items and advance the offset by the
+            # count actually returned.
+            while True:
+                page_msg = f"{logger_msg} for page {page_number}"
+                params = {
+                    "offset": offset,
+                    "limit": limit,
+                    # No space after the comma in the fields query
+                    # parameter else the Netskope API returns an error.
+                    "fields": "id,name,type,protocols,description",
+                }
+                if name:
+                    params["filter"] = f'name eq "{name}"'
+                response = self.netskope_helper._api_call_helper(
+                    url=url,
+                    method="get",
+                    error_codes=["CRE_1063", "CRE_1064"],
+                    headers=headers,
+                    params=params,
+                    proxies=self.proxy,
+                    message=f"Error occurred while {page_msg}",
+                    logger_msg=page_msg,
+                )
+                services = response.get("services", [])
+                for service in services:
+                    profile_name = service.get("name", "")
+                    profile_type = str(
+                        service.get("type", "")
+                    ).upper()
+                    if not profile_name:
+                        continue
+                    if (
+                        custom_only
+                        and profile_type != SERVICE_PROFILE_TYPE_CUSTOM
+                    ):
+                        continue
+                    profiles[profile_name] = service
+                if len(services) < limit:
+                    break
+                offset += len(services)
+                page_number += 1
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+        if name and len(profiles) > 0:
+            if len(profiles) > 0:
+                self.logger.debug(
+                    f"{self.log_prefix}: Successfully fetched Service "
+                    f"Profile '{name}' from the Netskope Tenant."
+                )
+        elif not name:
+            self.logger.debug(
+                f"{self.log_prefix}: Successfully fetched {len(profiles)} "
+                "service profile(s) from the Netskope Tenant."
+            )
+        return profiles
+
+    def _get_service_profile_by_name(self, name: str) -> Dict:
+        """Fetch a single CUSTOM service profile by its name.
+
+        Performs an exact ``name eq`` lookup against the service
+        profile listing and returns the matching CUSTOM profile,
+        including its existing ``protocols`` (needed to union ports
+        for an Append operation). PREDEFINED profiles are excluded
+        because they cannot be edited.
+
+        Args:
+            name (str): Name of the service profile to look up.
+
+        Returns:
+            Dict: The matching CUSTOM service profile object, or an
+                empty dict if no editable profile with that name
+                exists.
+        """
+        profiles = self._get_service_profiles(
+            custom_only=True,
+            name=name,
+        )
+        return profiles.get(name, {})
+
+    def _push_service_profile(
+        self,
+        operation: str,
+        profile_name: str,
+        description: str,
+        tcp: List[str],
+        udp: List[str],
+        tcp_udp: List[str],
+        icmp: bool,
+    ) -> tuple:
+        """Create or update a service profile on the Netskope Tenant.
+
+        When no editable (CUSTOM) profile named ``profile_name``
+        exists, a new profile is created via ``POST`` carrying the
+        assembled ``protocols``. Otherwise the existing profile is
+        updated via ``PATCH`` on its id. For an ``append`` operation
+        the new ports are unioned (de-duplicated, order preserved)
+        with the profile's existing ports for each protocol; for a
+        ``replace`` operation only the supplied ports are sent. Empty
+        protocol arrays are omitted from the payload. The selected ICMP
+        value is honoured on update for both operations (enabled adds
+        ``icmp: true``, disabled omits it), so an ``append`` can turn an
+        existing ICMP off as well as on. The ``description`` is also
+        applied on update, sent only when a value is provided that
+        differs from the profile's current description.
+
+        PREDEFINED profiles cannot be updated: a ``PATCH`` against
+        such an id returns HTTP 404. That case is detected explicitly
+        (``is_handle_error_required=False``) and surfaced as a clear
+        "predefined/not found" error.
+
+        Args:
+            operation (str): ``append`` to union with existing ports,
+                ``replace`` to overwrite with only the new ports.
+            profile_name (str): Target service profile name (existing
+                CUSTOM profile to update, or the name to create).
+            description (str): Description used when creating a profile.
+            tcp (List[str]): TCP ports/ranges to add.
+            udp (List[str]): UDP ports/ranges to add.
+            tcp_udp (List[str]): TCP_UDP ports/ranges to add.
+            icmp (bool): Whether ICMP is enabled for the profile.
+
+        Returns:
+            tuple: ``(applied_count, not_applied)`` where
+                ``applied_count`` is the number of ports applied and
+                ``not_applied`` is the list of ports that could not be
+                applied. A service profile update is all-or-nothing — the
+                API does not report a partial port rejection — so on
+                success ``not_applied`` is empty and every requested port
+                is counted as applied; a total failure raises and is
+                attributed to the action ids by the caller.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        new_ports = {
+            "tcp": [p for p in (tcp or []) if p],
+            "udp": [p for p in (udp or []) if p],
+            "tcp_udp": [p for p in (tcp_udp or []) if p],
+        }
+        existing_profile = self._get_service_profile_by_name(
+            profile_name
+        )
+        if existing_profile:
+            profile_id = existing_profile.get("id")
+            existing_protocols = existing_profile.get(
+                "protocols", {}
+            )
+            protocols = {}
+            for proto, ports in new_ports.items():
+                if operation == "append":
+                    merged = list(
+                        existing_protocols.get(proto, [])
+                    )
+                    for port in ports:
+                        if port not in merged:
+                            merged.append(port)
+                    if merged:
+                        protocols[proto] = merged
+                elif ports:
+                    protocols[proto] = ports
+            # The selected ICMP value is honoured for both Append and
+            # Replace: enabling adds ``icmp: true`` and disabling omits
+            # it from the protocols object (the PATCH replaces the whole
+            # object), so an Append can now turn an existing ICMP off as
+            # well as on, matching the user's selection.
+            if icmp:
+                protocols["icmp"] = True
+            body = {"protocols": protocols}
+            # The Description is applied on update too (it was previously
+            # sent only on create); send it only when a value is provided
+            # that differs from the profile's current description, so a
+            # no-op re-run does not clobber it.
+            existing_description = existing_profile.get("description", "")
+            if description and description != existing_description:
+                body["description"] = description
+            method = "patch"
+            profile_path = V2_SERVICE_PROFILE_BY_ID.format(profile_id)
+            url = f"{tenant_name}{profile_path}"
+            logger_msg = (
+                f"updating service profile '{profile_name}' on the "
+                "Netskope Tenant"
+            )
+        else:
+            protocols = {
+                proto: ports
+                for proto, ports in new_ports.items()
+                if ports
+            }
+            if icmp:
+                protocols["icmp"] = True
+            body = {
+                "name": profile_name,
+                "description": description,
+                "protocols": protocols,
+            }
+            method = "post"
+            url = f"{tenant_name}{V2_SERVICE_PROFILE}"
+            logger_msg = (
+                f"creating service profile '{profile_name}' on the "
+                "Netskope Tenant"
+            )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
+        try:
+            response = self.netskope_helper._api_call_helper(
+                url=url,
+                method=method,
+                error_codes=["CRE_1063", "CRE_1064"],
+                headers=headers,
+                json=body,
+                proxies=self.proxy,
+                message=f"Error occurred while {logger_msg}",
+                logger_msg=logger_msg,
+                is_handle_error_required=False,
+            )
+            if method == "patch" and response.status_code == 404:
+                error_message = (
+                    f"Service profile '{profile_name}' could not be "
+                    "updated because it was not found or is a "
+                    "PREDEFINED profile. Only CUSTOM service profiles "
+                    "are editable."
+                )
+                self.logger.error(
+                    message=f"{self.log_prefix}: {error_message}",
+                    details=str(response.text),
+                    resolution=(
+                        "Select a CUSTOM service profile (PREDEFINED "
+                        "profiles cannot be modified) or create a new "
+                        "service profile, then re-run the action."
+                    ),
+                )
+                raise NetskopeException(error_message)
+            handle_status_code(
+                response,
+                error_code="CRE_1064",
+                custom_message=f"Error occurred while {logger_msg}",
+                plugin=self.log_prefix,
+                notify=False,
+                log=True,
+            )
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            raise NetskopeException(error_message)
+        action_verb = "updated" if method == "patch" else "created"
+        self.logger.info(
+            f"{self.log_prefix}: Successfully {action_verb} service "
+            f"profile '{profile_name}' on the Netskope Tenant."
+        )
+        applied_count = (
+            len(new_ports["tcp"])
+            + len(new_ports["udp"])
+            + len(new_ports["tcp_udp"])
+        )
+        return applied_count, []
+
+    def _get_device_classifications(self) -> Dict:
+        """Fetch device classifications from the Netskope Tenant.
+
+        Paginates through ``GET /api/v2/deviceclassification/tags`` and
+        returns a mapping of device classification name to its id,
+        suitable for building action dropdowns and for checking whether a
+        classification already exists before creating it. The endpoint
+        returns a bare JSON array of classification objects.
+
+        Returns:
+            Dict: Mapping of device classification name to its id.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = (
+            f"{tenant_name}"
+            f"{URLS.get('V2_DEVICE_CLASSIFICATION_TAGS')}"
+        )
+        classifications = {}
+        offset = 0
+        limit = DEVICE_CLASSIFICATION_PAGE_SIZE
+        page_number = 1
+        logger_msg = (
+            "fetching device classifications from the Netskope Tenant"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {logger_msg.capitalize()}."
+        )
+        try:
+            while True:
+                page_msg = f"{logger_msg} for page {page_number}"
+                params = {"offset": offset, "limit": limit}
+                response = self.netskope_helper._api_call_helper(
+                    url=url,
+                    method="get",
+                    error_codes=["CRE_1063", "CRE_1064"],
+                    headers=headers,
+                    params=params,
+                    proxies=self.proxy,
+                    message=f"Error occurred while {page_msg}",
+                    logger_msg=page_msg,
+                )
+                tags = (
+                    response
+                    if isinstance(response, list)
+                    else response.get("data", [])
+                )
+                if not tags:
+                    break
+                for tag in tags:
+                    name = tag.get("name", "")
+                    tag_id = tag.get("id")
+                    if name and tag_id is not None:
+                        classifications[name] = tag_id
+                if len(tags) < limit:
+                    break
+                offset += limit
+                page_number += 1
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=str(traceback.format_exc()),
+            )
+            raise NetskopeException(error_message)
+        self.logger.debug(
+            f"{self.log_prefix}: Successfully fetched "
+            f"{len(classifications)} device classification(s) from the "
+            "Netskope Tenant."
+        )
+        return classifications
+
+    def _get_device_classification_rules(self) -> List[Dict]:
+        """Fetch device classification rules from the Netskope Tenant.
+
+        Paginates through ``GET /api/v2/deviceclassification/rules`` and
+        returns the full rule objects (including ``id``, ``name``,
+        ``label``, ``os`` and ``conditions``). The conditions are needed
+        to union the existing device tags for an Append operation, and
+        the id is needed to target a rule for an update. The endpoint
+        returns a bare JSON array of rule objects.
+
+        Returns:
+            List[Dict]: List of device classification rule objects.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = (
+            f"{tenant_name}"
+            f"{URLS.get('V2_DEVICE_CLASSIFICATION_RULES')}"
+        )
+        rules = []
+        offset = 0
+        limit = DEVICE_CLASSIFICATION_PAGE_SIZE
+        page_number = 1
+        logger_msg = (
+            "fetching device classification rules from the Netskope "
+            "Tenant"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {logger_msg.capitalize()}."
+        )
+        try:
+            while True:
+                page_msg = f"{logger_msg} for page {page_number}"
+                params = {"offset": offset, "limit": limit}
+                response = self.netskope_helper._api_call_helper(
+                    url=url,
+                    method="get",
+                    error_codes=["CRE_1063", "CRE_1064"],
+                    headers=headers,
+                    params=params,
+                    proxies=self.proxy,
+                    message=f"Error occurred while {page_msg}",
+                    logger_msg=page_msg,
+                )
+                page_rules = (
+                    response
+                    if isinstance(response, list)
+                    else response.get("data", [])
+                )
+                if not page_rules:
+                    break
+                rules.extend(page_rules)
+                if len(page_rules) < limit:
+                    break
+                offset += limit
+                page_number += 1
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=str(traceback.format_exc()),
+            )
+            raise NetskopeException(error_message)
+        self.logger.debug(
+            f"{self.log_prefix}: Successfully fetched {len(rules)} "
+            "device classification rule(s) from the Netskope Tenant."
+        )
+        return rules
+
+    def _create_device_classification(
+        self,
+        name: str,
+        existing_classifications: Dict,
+    ) -> None:
+        """Create a device classification on the Netskope Tenant.
+
+        Creates the classification via ``POST`` only when one with the
+        same name does not already exist, so re-running the action with
+        the same name reuses the existing classification instead of
+        attempting a duplicate create (which the API rejects). The
+        request body is a JSON array carrying a single classification
+        object, as required by the endpoint.
+
+        Args:
+            name (str): Name of the device classification to create.
+            existing_classifications (Dict): Mapping of existing
+                classification name to id, used to skip creation when the
+                classification already exists.
+        """
+        if name in existing_classifications:
+            self.logger.info(
+                f"{self.log_prefix}: Device classification '{name}' "
+                "already exists on the Netskope Tenant; reusing it "
+                "instead of creating a new one."
+            )
+            return
+        tenant_name, headers = self._get_tenant_and_headers()
+        url = (
+            f"{tenant_name}"
+            f"{URLS.get('V2_DEVICE_CLASSIFICATION_TAGS')}"
+        )
+        body = [
+            {
+                "name": name,
+                "description": DEVICE_CLASSIFICATION_DEFAULT_DESCRIPTION,
+            }
+        ]
+        logger_msg = (
+            f"creating device classification '{name}' on the Netskope "
+            "Tenant"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
+        response = self.netskope_helper._api_call_helper(
+            url=url,
+            method="post",
+            error_codes=["CRE_1063", "CRE_1064"],
+            headers=headers,
+            json=body,
+            proxies=self.proxy,
+            message=f"Error occurred while {logger_msg}",
+            logger_msg=logger_msg,
+        )
+        if (
+            isinstance(response, dict)
+            and not response.get("status", True)
+        ):
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=f"{self.log_prefix}: {error_message}",
+                details=str(response),
+                resolution=(
+                    "Verify the device classification name is valid and "
+                    "does not already exist, then re-run the action."
+                ),
+            )
+            raise NetskopeException(error_message)
+        self.logger.info(
+            f"{self.log_prefix}: Successfully {logger_msg}."
+        )
+
+    def _send_classification_rule_request(
+        self, method, url, body, headers, logger_msg
+    ):
+        """Send a device classification rule create/update request.
+
+        Issues the ``POST`` (create) or ``PUT`` (update) request for a
+        device classification rule and handles its responses: an HTTP
+        409 (the same classification criteria already exist on another
+        rule) is surfaced with the conflicting rule's message, and any
+        other non-2xx status is routed through ``handle_status_code``.
+        The rule endpoints return an empty body on success, so the
+        error handler is only invoked for non-success status codes.
+        Raises ``NetskopeException`` on any failure.
+
+        Args:
+            method (str): ``post`` to create a rule or ``put`` to update
+                an existing rule by id.
+            url (str): Fully-qualified rule endpoint URL.
+            body (Union[dict, list]): Request body (a single-object
+                array for create, a rule object for update).
+            headers (dict): Request headers carrying the v2 API token.
+            logger_msg (str): Present-participle description of the call
+                used in error and conflict messages.
+        """
+        try:
+            response = self.netskope_helper._api_call_helper(
+                url=url,
+                method=method,
+                error_codes=["CRE_1063", "CRE_1064"],
+                headers=headers,
+                json=body,
+                proxies=self.proxy,
+                message=f"Error occurred while {logger_msg}",
+                logger_msg=logger_msg,
+                is_handle_error_required=False,
+            )
+            # The rule create/update endpoints return an empty body on
+            # success (201/200), so only invoke the error handler for
+            # non-success status codes to avoid parsing an empty body.
+            if response.status_code == 409:
+                try:
+                    conflict_msg = response.json().get(
+                        "message",
+                        "A conflicting device classification rule"
+                        " already exists.",
+                    )
+                except Exception:
+                    conflict_msg = (
+                        "A conflicting device classification rule"
+                        " already exists."
+                    )
+                error_message = (
+                    f"Error occurred while {logger_msg}."
+                    f" {conflict_msg}"
+                )
+                self.logger.error(
+                    message=f"{self.log_prefix}: {error_message}",
+                    resolution=(
+                        "A device classification rule with the same"
+                        " classification criteria already exists on"
+                        " the Netskope Tenant. Modify the Tags,"
+                        " Match Type, or Operating System to make"
+                        " the rule criteria unique."
+                    ),
+                )
+                raise NetskopeException(error_message)
+            elif not 200 <= response.status_code < 300:
+                handle_status_code(
+                    response,
+                    error_code="CRE_1064",
+                    custom_message=f"Error occurred while {logger_msg}",
+                    plugin=self.log_prefix,
+                    notify=False,
+                    log=True,
+                )
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = f"Error occurred while {logger_msg}."
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: {error_message} "
+                    f"Error: {err}"
+                ),
+                details=str(traceback.format_exc()),
+            )
+            raise NetskopeException(error_message)
+
+    def _move_rule_classification(
+        self,
+        rule_id,
+        existing_rule,
+        label,
+        rule_name,
+        os,
+        tenant_name,
+        headers,
+    ):
+        """Reassign an existing rule to a different classification.
+
+        Used when a short-circuit (the rule is already full, every
+        provided tag is already on the rule, or no device tag is left to
+        apply) means the rule's device tags do not change, but the
+        selected device classification differs from the rule's current
+        one. A Netskope rule can belong to only one classification, so
+        the rule is updated in place with its existing conditions left
+        untouched and only its ``label`` (the classification) changed.
+        Raises ``NetskopeException`` on failure.
+
+        Args:
+            rule_id (str): Id of the rule to update.
+            existing_rule (dict): The rule object fetched from the
+                tenant; its ``conditions`` are preserved verbatim.
+            label (str): The new device classification name to move the
+                rule to.
+            rule_name (str): Rule name (used in the body and logs).
+            os (str): Target operating system of the rule.
+            tenant_name (str): Base tenant URL.
+            headers (dict): Request headers carrying the v2 API token.
+        """
+        rule_path = URLS.get(
+            "V2_DEVICE_CLASSIFICATION_RULE_BY_ID"
+        ).format(rule_id)
+        url = f"{tenant_name}{rule_path}"
+        body = {
+            "conditions": existing_rule.get("conditions", {}),
+            "label": label,
+            "name": rule_name,
+            "os": os,
+        }
+        logger_msg = (
+            f"moving device classification rule '{rule_name}' to"
+            f" classification '{label}' on the Netskope Tenant"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
+        self._send_classification_rule_request(
+            "put", url, body, headers, logger_msg
+        )
+        self.logger.info(
+            f"{self.log_prefix}: Successfully moved device"
+            f" classification rule '{rule_name}' to classification"
+            f" '{label}' on the Netskope Tenant."
+        )
+
+    def _push_device_classification(
+        self,
+        operation: str,
+        classification_value: str,
+        new_classification_name: str,
+        rule_value: str,
+        new_rule_name: str,
+        os: str,
+        operator: str,
+        group_operator: str,
+        tags: List[str],
+    ) -> tuple:
+        """Create/update a device classification and its rule.
+
+        Ensures the target device classification exists (creating it when
+        'Create new Device Classification' was selected), resolves the
+        provided device tag names to ids, builds the rule's condition tree
+        and then creates the rule (``POST`` with a single-object array) or
+        updates an existing rule (``PUT`` on its id). For an Append
+        operation against an existing rule the new device tags are unioned
+        with the rule's current tags; for Replace the rule's device tags
+        are overwritten with only the new tags. When updating an existing
+        rule, only its device tag checks are changed (via
+        ``_replace_rule_tag_checks``) and every other condition branch is
+        preserved; a brand-new rule gets a freshly built condition tree.
+        The action fails (raises)
+        if any provided device tag does not exist on the Netskope Tenant
+        (tags are never created here).
+
+        Args:
+            operation (str): ``append`` to union with the existing rule's
+                device tags, ``replace`` to overwrite them.
+            classification_value (str): Selected classification name, or
+                the literal ``"create"`` to create a new one.
+            new_classification_name (str): Name used when creating a
+                classification.
+            rule_value (str): Packed ``name<sep>id`` of the selected rule,
+                or a ``<sep>create`` value to create a new rule.
+            new_rule_name (str): Name used when creating a rule.
+            os (str): Target operating system for the rule.
+            operator (str): ``and`` or ``or`` inner tag group logical
+                operator (from Match Type).
+            group_operator (str): ``and`` or ``or`` outer container
+                operator joining multiple tag groups (from Group Match
+                Type).
+            tags (List[str]): Device tag names to reference in the rule.
+
+        Returns:
+            tuple: ``(applied_count, not_applied, action_status)`` where
+                ``applied_count`` is the number of NEW device tags added
+                to the rule (device tags already present on the rule are
+                not counted), ``not_applied`` is the list of provided tag
+                names that were skipped because of the rule's tag limit
+                (tags beyond the first 5, the new tags that did not fit an
+                existing rule, or every provided tag when the rule is
+                already full) so the caller can attribute each back to its
+                originating action id(s) via ``value_to_ids``, and
+                ``action_status`` is ``"created"`` when a new rule was
+                created or ``"updated"`` when an existing rule was
+                targeted (including the self-heal case and the skip
+                paths). Tags that do not exist on the Netskope Tenant
+                still raise (the whole group fails). A failure to create
+                the classification, resolve the tags or push the rule
+                raises and is attributed to the action id(s) by the
+                caller.
+        """
+        tenant_name, headers = self._get_tenant_and_headers()
+        # Resolve the classification label, creating the classification
+        # when 'Create new Device Classification' was selected.
+        if classification_value == "create":
+            label = new_classification_name
+            existing_classifications = (
+                self._get_device_classifications()
+            )
+            self._create_device_classification(
+                label, existing_classifications
+            )
+        else:
+            label = classification_value
+        # Resolve the target rule: an existing rule is updated by id; a
+        # new rule name is created, or updated if a rule with that name
+        # and OS already exists so that re-runs do not duplicate it. When
+        # the matched rule sits in a different classification, it is moved
+        # to the selected one as part of the normal update (a rule belongs
+        # to exactly one classification).
+        rule_name, _, rule_id_token = rule_value.rpartition(
+            CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION
+        )
+        existing_rule = {}
+        if rule_id_token == "create":
+            rule_name = new_rule_name
+            rule_id = None
+            for rule in self._get_device_classification_rules():
+                if rule.get("name", "") != rule_name:
+                    # A different rule -- keep searching for the name.
+                    continue
+                # A rule with this name already exists on the tenant
+                # (rule names are unique, so a create with an existing
+                # name is rejected with a 409). Its OS cannot be changed
+                # -- mirroring the Netskope UI -- so when the selected OS
+                # differs from the existing rule's OS the action is
+                # short-circuited with an error instead of issuing a POST
+                # that the tenant rejects with a 409.
+                existing_os = rule.get("os", "")
+                if str(existing_os).lower() != os.lower():
+                    error_message = (
+                        "Cannot change the operating system for device"
+                        f" classification rule '{rule_name}' from"
+                        f" '{existing_os}' to '{os}'; hence skipping the"
+                        " Create Device Classification action execution."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {error_message}",
+                        resolution=(
+                            "The operating system of an existing rule"
+                            " cannot be changed. Provide the rule's"
+                            f" current operating system '{existing_os}',"
+                            " either use a different rule or create a new"
+                            f" rule for with operating system {os}."
+                        ),
+                    )
+                    raise NetskopeException(error_message)
+                # Same name and OS -> reuse (update) the existing rule
+                # instead of creating a duplicate.
+                rule_id = rule.get("id")
+                existing_rule = rule
+                self.logger.info(
+                    f"{self.log_prefix}: Device classification rule "
+                    f"'{rule_name}' already exists on the Netskope "
+                    "Tenant; updating it instead of creating a new "
+                    "one."
+                )
+                break
+        else:
+            rule_id = rule_id_token
+            for rule in self._get_device_classification_rules():
+                if str(rule.get("id", "")) == str(rule_id):
+                    existing_rule = rule
+                    break
+            if not existing_rule:
+                error_message = (
+                    f"Device classification rule '{rule_name}' could "
+                    "not be found on the Netskope Tenant."
+                )
+                self.logger.error(
+                    message=f"{self.log_prefix}: {error_message}",
+                    resolution=(
+                        "Verify the device classification rule still "
+                        "exists on the Netskope Tenant and re-run the "
+                        "action."
+                    ),
+                )
+                raise NetskopeException(error_message)
+            # Case 1: the operating system of an existing rule cannot be
+            # changed (the Netskope UI does not allow it either), so a
+            # mismatch is an error and the action is short-circuited for
+            # this rule rather than attempting a forbidden OS change.
+            existing_os = existing_rule.get("os", "")
+            if str(existing_os).lower() != os.lower():
+                error_message = (
+                    "Cannot change the operating system for device"
+                    f" classification rule '{rule_name}' from"
+                    f" '{existing_os}' to '{os}'; hence skipping the"
+                    " Create Device Classification action execution."
+                )
+                self.logger.error(
+                    message=f"{self.log_prefix}: {error_message}",
+                    resolution=(
+                        "The operating system of an existing rule"
+                        " cannot be changed. Select the rule's current"
+                        f" operating system '{existing_os}' in the"
+                        " action configuration, or create a new rule"
+                        " for the desired operating system."
+                    ),
+                )
+                raise NetskopeException(error_message)
+        # A rule targeted by id (an existing rule, including the
+        # self-heal case where a create resolves to an existing rule) is
+        # updated; otherwise a brand-new rule is created. This status is
+        # returned so the caller can log/report the right verb.
+        action_status = "updated" if rule_id is not None else "created"
+        # The selected device classification becomes the rule's label.
+        # A Netskope rule can belong to only one classification, so when
+        # an existing rule's current classification differs from the
+        # selected one the rule must be moved to it even if its device
+        # tags do not change (the short-circuit paths below).
+        existing_label = (
+            existing_rule.get("label", "") if existing_rule else ""
+        )
+        label_changed = bool(existing_rule) and existing_label != label
+        # Tags that exceed DEVICE_CLASSIFICATION_TAGS_PER_GROUP per group
+        # are split into additional condition groups instead of discarded.
+        existing_tag_ids = []
+        if existing_rule:
+            existing_tag_ids = self.netskope_helper._extract_rule_tag_ids(
+                existing_rule.get("conditions", {})
+            )
+        # Resolve all provided device tag names to ids. Tags that do not
+        # exist on the Netskope Tenant cause the whole group to fail.
+        tag_cache = self._fetch_all_tags()
+        new_tag_ids, not_found = self.netskope_helper._resolve_classification_tag_ids(
+            tags, tag_cache
+        )
+        if not_found:
+            error_message = (
+                "Some of the provided Tags do not exist on the "
+                "Netskope Tenant. Hence skipping the Create Device "
+                "Classification action execution."
+            )
+            self.logger.error(
+                message=f"{self.log_prefix}: {error_message}",
+                details=(
+                    "Tags not found on the Netskope Tenant: "
+                    f"{', '.join(not_found)}."
+                ),
+                resolution=(
+                    "Create these device tags on the Netskope Tenant "
+                    "or provide existing device tag names, then re-run "
+                    "the action."
+                ),
+            )
+            raise NetskopeException(error_message)
+        # Map resolved tag ids back to the provided names for logging.
+        id_to_name = {}
+        for tag in tags:
+            resolved_id = tag_cache.get(str(tag).strip().lower())
+            if resolved_id is not None and resolved_id not in id_to_name:
+                id_to_name[resolved_id] = str(tag).strip()
+        # Append unions the new device tags with the rule's current tags;
+        # tags that exceed DEVICE_CLASSIFICATION_TAGS_PER_GROUP per group
+        # are split into additional condition groups instead of discarded.
+        # Replace (or a brand-new rule) uses only the new tags.
+        # ``added_tag_ids`` are the newly added tags only — tags already
+        # present on the rule are never counted.
+        if existing_rule and operation == "append":
+            final_tag_ids = list(existing_tag_ids)
+            added_tag_ids = []
+            for tag_id in new_tag_ids:
+                if tag_id in final_tag_ids:
+                    # Already on the rule — not a newly added tag.
+                    continue
+                final_tag_ids.append(tag_id)
+                added_tag_ids.append(tag_id)
+            if new_tag_ids and not added_tag_ids:
+                self.logger.info(
+                    f"{self.log_prefix}: All the provided tags already "
+                    "exist in the device classification rule "
+                    f"'{rule_name}'. Hence skipping the action "
+                    "execution. 0 new device tag(s) were added."
+                )
+                # The rule's device tags do not change, but if the
+                # selected classification differs the rule is still
+                # moved to it.
+                if label_changed:
+                    self._move_rule_classification(
+                        rule_id,
+                        existing_rule,
+                        label,
+                        rule_name,
+                        os,
+                        tenant_name,
+                        headers,
+                    )
+                return (
+                    0,
+                    list(not_found),
+                    action_status,
+                )
+        else:
+            final_tag_ids = list(new_tag_ids)
+            added_tag_ids = [
+                tag_id
+                for tag_id in new_tag_ids
+                if tag_id not in existing_tag_ids
+            ]
+        if not final_tag_ids:
+            self.logger.info(
+                f"{self.log_prefix}: No device tags were provided to "
+                f"apply to the device classification rule "
+                f"'{rule_name}'. Skipping action execution."
+            )
+            # No device tag change, but if the selected classification
+            # differs the rule is still moved to it. The rule's existing
+            # conditions are sent verbatim, so a rule with no conditions
+            # to preserve is left untouched (never wiped to empty).
+            if label_changed and existing_rule.get("conditions"):
+                self._move_rule_classification(
+                    rule_id,
+                    existing_rule,
+                    label,
+                    rule_name,
+                    os,
+                    tenant_name,
+                    headers,
+                )
+            return (
+                0,
+                list(not_found),
+                action_status,
+            )
+        # When updating an existing rule, touch ONLY its device tags:
+        # swap the tag checks inside the existing conditions and leave
+        # every other condition branch (min OS version, not-compromised,
+        # ...) intact. A brand-new rule gets a freshly built tree.
+        if existing_rule:
+            conditions = self.netskope_helper._replace_rule_tag_checks(
+                existing_rule.get("conditions", {}),
+                final_tag_ids,
+                operator,
+                group_operator,
+            )
+        else:
+            conditions = self.netskope_helper._build_rule_conditions(
+                final_tag_ids, operator, group_operator
+            )
+        rule_body = {
+            "conditions": conditions,
+            "label": label,
+            "name": rule_name,
+            "os": os,
+        }
+        if rule_id is not None:
+            method = "put"
+            rule_path = URLS.get(
+                "V2_DEVICE_CLASSIFICATION_RULE_BY_ID"
+            ).format(rule_id)
+            url = f"{tenant_name}{rule_path}"
+            body = rule_body
+            logger_msg = (
+                f"updating device classification rule '{rule_name}'"
+                f" in classification '{label}' on the Netskope"
+                " Tenant"
+            )
+            final_logger = (
+                f"updated device classification rule '{rule_name}'"
+                f" in classification '{label}' on the Netskope"
+                " Tenant"
+            )
+        else:
+            method = "post"
+            url = (
+                f"{tenant_name}"
+                f"{URLS.get('V2_DEVICE_CLASSIFICATION_RULES')}"
+            )
+            body = [rule_body]
+            logger_msg = (
+                f"creating device classification rule '{rule_name}'"
+                f" in classification '{label}' on the Netskope"
+                " Tenant"
+            )
+            final_logger = (
+                f"created device classification rule '{rule_name}'"
+                f" in classification '{label}' on the Netskope"
+                " Tenant"
+            )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
+        self._send_classification_rule_request(
+            method, url, body, headers, logger_msg
+        )
+        self.logger.info(
+            f"{self.log_prefix}: Successfully {final_logger}."
+            f" Added {len(added_tag_ids)} new device tag(s) to the"
+            f" rule '{rule_name}'."
+        )
+        return (
+            len(added_tag_ids),
+            list(not_found),
+            action_status,
+        )
+
     def get_actions(self):
         """Get available actions."""
         return [
@@ -1289,6 +4309,20 @@ class NetskopePlugin(PluginBase):
             ),
             ActionWithoutParams(
                 label="Tag/Untag Device", value="tag_device"
+            ),
+            ActionWithoutParams(
+                label="Add to Destination Profile",
+                value="destination_profile",
+            ),
+            ActionWithoutParams(
+                label="Add to DNS Profile", value="dns_profile"
+            ),
+            ActionWithoutParams(
+                label="Add to Service Profile", value="service_profile"
+            ),
+            ActionWithoutParams(
+                label="Create Device Classification",
+                value="device_classification",
             ),
             ActionWithoutParams(label="No actions", value="generate"),
         ]
@@ -1744,7 +4778,7 @@ class NetskopePlugin(PluginBase):
         )
         logger_msg = f"creating group '{name}'"
         self.logger.debug(
-            f"{self.log_prefix}: {logger_msg.capitalize()} on "
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)} on "
             "the Netskope Tenant."
         )
         try:
@@ -1990,22 +5024,42 @@ class NetskopePlugin(PluginBase):
                     "alerts": ["uba"],
                 }
             modified_type_map = type_map.copy()
-            if "events" in modified_type_map and "clientstatus" in modified_type_map.get("events", []):
+            clientstatus_requested = (
+                "events" in modified_type_map
+                and "clientstatus" in modified_type_map.get("events", [])
+            )
+            if clientstatus_requested:
+                modified_type_map["events"] = [
+                    event_type
+                    for event_type in modified_type_map.get("events", [])
+                    if event_type != "clientstatus"
+                ]
+            else:
                 try:
-                    provider.client_status_validation()
-                    modified_type_map["events"] = [
-                        event_type
-                        for event_type in modified_type_map.get("events", [])
-                        if event_type != "clientstatus"
-                    ]
+                    provider.unregister_client_status_consumer(
+                        "cre", self.name
+                    )
                 except Exception as e:
-                    return ValidationResult(success=False, message=str(e))
+                    self.logger.error(
+                        f"{self.log_prefix}: Error while releasing "
+                        f"client_status subscription for CRE plugin "
+                        f"'{self.name}': {e}"
+                    )
 
             provider.permission_check(
                 modified_type_map,
                 plugin_name=self.plugin_name,
                 configuration_name=self.name,
             )
+
+            # Register only after all other validations pass — prevents a
+            # stale True subscriber leaf when permission_check fails and the
+            # plugin stays disabled.
+            if clientstatus_requested:
+                try:
+                    provider.register_client_status_consumer("cre", self.name)
+                except Exception as e:
+                    return ValidationResult(success=False, message=str(e))
 
             logger_msg = (
                 "Successfully validated the plugin "
@@ -2031,6 +5085,55 @@ class NetskopePlugin(PluginBase):
             return ValidationResult(
                 success=False,
                 message=f"{err_msg} Check logs for more details.",
+            )
+
+    def cleanup(self, action_type: str = "disable"):
+        """
+        Release this CRE plugin configuration's hold on the shared
+        client_status iterator when the plugin is disabled or deleted.
+
+        Resolves the associated tenant, fetches the Netskope provider, and
+        calls ``unregister_client_status_consumer("cre", self.name, ...)``
+        with ``deleted`` derived from ``action_type``:
+
+          * ``action_type == "delete"`` -> ``deleted=True``: the leaf is
+            removed from the subscriber registry entirely (config is gone).
+          * ``action_type == "disable"`` (or anything else) ->
+            ``deleted=False``: the leaf is set to False (config still
+            exists but is opted out of client_status).
+
+        If this call drops the last active subscriber, the provider will
+        delete the shared iterator on the tenant.
+
+        Errors are caught and logged rather than raised so a transient
+        provider problem cannot block plugin disable/delete.
+
+        Args:
+            action_type (str): Cleanup action identifier passed by the
+                framework — typically the value of
+                ``ActionType.DELETE`` (``"delete"``) or
+                ``ActionType.DISABLE`` (``"disable"``). Defaults to
+                ``"disable"``, the safer of the two: the leaf is set to
+                False (opted out) rather than removed, so the shared
+                iterator is not torn down on an ambiguous call.
+
+        Returns:
+            None
+        """
+        try:
+            helper = AlertsHelper()
+            tenant_name = helper.get_tenant_crev2(self.name).name
+            provider = plugin_provider_helper.get_provider(
+                tenant_name=tenant_name
+            )
+            provider.unregister_client_status_consumer(
+                "cre", self.name, deleted=(action_type == "delete")
+            )
+        except Exception as e:
+            self.logger.error(
+                f"{self.log_prefix}: Error while releasing client_status "
+                f"subscription on CRE plugin '{self.name}' "
+                f"(action_type={action_type}): {e}"
             )
 
     def _validate_required_field_in_entity_mappings(self):
@@ -2085,37 +5188,161 @@ class NetskopePlugin(PluginBase):
 
         return True, ""
 
-    def _validate_port(self, port):
-        """Validate the port or port range.
+    def _validate_parameters(
+        self,
+        field_name: str,
+        field_value,
+        field_type: type,
+        parameter_type: Literal["configuration", "action"],
+        allowed_values: Dict = None,
+        custom_validation_func: Callable = None,
+        is_required: bool = True,
+        validation_err_msg: str = "Validation error occurred. ",
+        check_dollar: bool = False,
+        is_source_field_allowed: bool = True,
+    ) -> Union[ValidationResult, None]:
+        """Validate a configuration or action parameter.
 
         Args:
-            port: Port number as int/str or port range as 'lower-upper' string
+            field_name (str): Parameter name.
+            field_value: Parameter value.
+            field_type (type): Expected type.
+            parameter_type (Literal["configuration", "action"]):
+                Type of parameter used in error messages.
+            allowed_values (Dict, optional): Dict or list of allowed
+                values.
+            custom_validation_func (Callable, optional): Custom
+                validation function.
+            is_required (bool): Whether the field is required.
+            validation_err_msg (str): Error message prefix.
+            check_dollar (bool): Skip validation if source field.
+            is_source_field_allowed (bool): Whether source fields
+                are allowed.
 
         Returns:
-            bool: True if port or port range is valid, False otherwise
+            ValidationResult or None.
         """
-        # Handle port range (e.g., '1000-2000')
-        if isinstance(port, str) and '-' in port:
-            try:
-                lower, upper = port.split('-')
-                lower_port = int(lower.strip())
-                upper_port = int(upper.strip())
-                # Check if ports are within valid range
-                if not (0 <= lower_port <= 65535 and 0 <= upper_port <= 65535):
-                    return False
-                # Check if lower is less than upper and they are not equal
-                if lower_port >= upper_port:
-                    return False
-                return True
-            except (ValueError, AttributeError):
-                return False
+        if (
+            not is_source_field_allowed
+            and isinstance(field_value, str)
+            and "$" in field_value
+        ):
+            err_msg = (
+                f"'{field_name}' can only contain the Static Field."
+            )
+            self.logger.error(
+                message=f"{self.log_prefix}: {err_msg}",
+                resolution=(
+                    f"Ensure that Static is selected for the"
+                    f" field '{field_name}' in the action"
+                    " configuration."
+                ),
+            )
+            return ValidationResult(success=False, message=err_msg)
 
-        # Handle single port
-        try:
-            port = int(port)
-            return 0 <= port <= 65535
-        except (ValueError, TypeError):
-            return False
+        if field_type is str and isinstance(field_value, str):
+            field_value = field_value.strip()
+
+        if (
+            check_dollar
+            and isinstance(field_value, str)
+            and "$" in field_value
+        ):
+            self.logger.info(
+                message=(
+                    f"{self.log_prefix}: '{field_name}' contains"
+                    " the Source Field hence validation for this"
+                    " field will be performed while executing the"
+                    " action."
+                ),
+            )
+            return None
+
+        if (
+            is_required
+            and not isinstance(field_value, (int, float))
+            and not field_value
+        ):
+            err_msg = (
+                f"'{field_name}' is a required"
+                f" {parameter_type} parameter."
+            )
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: "
+                    f"{validation_err_msg}{err_msg}"
+                ),
+                resolution=(
+                    "Ensure that some value is provided for"
+                    f" field {field_name}."
+                ),
+            )
+            return ValidationResult(success=False, message=err_msg)
+
+        if is_required and not isinstance(field_value, field_type):
+            err_msg = (
+                f"Invalid value provided for the {parameter_type}"
+                f" parameter '{field_name}'."
+            )
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: "
+                    f"{validation_err_msg}{err_msg}"
+                ),
+                resolution=(
+                    "Ensure that a valid value is provided for"
+                    f" {field_name} field."
+                ),
+            )
+            return ValidationResult(success=False, message=err_msg)
+
+        if custom_validation_func and not custom_validation_func(
+            field_value
+        ):
+            err_msg = (
+                f"Invalid value provided for the {parameter_type}"
+                f" parameter '{field_name}'."
+            )
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: "
+                    f"{validation_err_msg}{err_msg}"
+                ),
+                resolution=(
+                    "Ensure that a valid value is provided for"
+                    f" {field_name} field."
+                ),
+            )
+            return ValidationResult(success=False, message=err_msg)
+
+        if allowed_values and isinstance(field_value, str):
+            if field_value not in allowed_values:
+                if len(allowed_values) <= 5:
+                    err_msg = (
+                        f"Invalid value provided for the"
+                        f" {parameter_type} parameter '{field_name}'."
+                        " Allowed values are"
+                        f" {', '.join(str(v) for v in allowed_values)}."
+                    )
+                else:
+                    err_msg = (
+                        f"Invalid value for '{field_name}' provided"
+                        f" in the {parameter_type} parameters."
+                    )
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: "
+                        f"{validation_err_msg}{err_msg}"
+                    ),
+                    resolution=(
+                        "Ensure that a valid value is provided"
+                        " from the allowed values."
+                    ),
+                )
+                return ValidationResult(
+                    success=False, message=err_msg
+                )
+        return None
 
     def validate_action(self, action: Action):
         """Validate Netskope configuration.
@@ -2183,22 +5410,114 @@ class NetskopePlugin(PluginBase):
                 self.logger.info(
                     f"{self.log_prefix}: "
                     f"Exception occurred while validating action parameters.",
-                    details=traceback.format_exc(),
+                    details=re.sub(
+                        r"token=([0-9a-zA-Z]*)",
+                        "token=********&",
+                        traceback.format_exc(),
+                    ),
                     error_code="CRE_1042",
                 )
                 return ValidationResult(success=False, message=str(e))
 
+            skip_excess_hosts = action.parameters.get(
+                "skip_excess_hosts", False
+            )
+            if skip_excess_hosts not in [True, False]:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Invalid value provided for the "
+                        "action parameter 'Skip Excess Hosts'."
+                    ),
+                    resolution=(
+                        "Select either 'Yes' or 'No' for 'Skip Excess "
+                        "Hosts' from the Static field dropdown."
+                    ),
+                )
+                return ValidationResult(
+                    success=False,
+                    message="Invalid Skip Excess Hosts provided.",
+                )
+
             tags = action.parameters.get("tags", "")
+            # For a Static Tags field, validate every tag at save time and
+            # fail the configuration if any tag is empty or exceeds the
+            # maximum allowed length. For a Source field ("$" present) the
+            # validation is deferred to action execution, where invalid
+            # tags are skipped and the remaining valid tags are pushed.
             if tags and "$" not in tags:
-                for tag in tags.split(","):
-                    if len(tag.strip()) > 30:
-                        return ValidationResult(
-                            success=False,
-                            message=(
-                                "Each tag should be less than or equal "
-                                "to 30 characters."
-                            ),
-                        )
+                tags_to_validate = [
+                    tag.strip() for tag in tags.split(",") if tag.strip()
+                ]
+                _, skipped_tags, skip_count = (
+                    self.netskope_helper.validate_tags_for_private_app(
+                        tags_to_push=tags_to_validate,
+                        private_app_name=action.parameters.get(
+                            "private_app_name", ""
+                        ),
+                    )
+                )
+                if skip_count > 0:
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: {skip_count} tag(s) "
+                            "provided in the Tags field are empty or exceed "
+                            "the maximum allowed character limit of "
+                            f"{PRIVATE_APP_TAG_MAX_LENGTH}."
+                        ),
+                        details=f"Invalid Tags: {', '.join(skipped_tags)}",
+                        resolution=(
+                            "Provide tags that are non-empty and do not "
+                            f"exceed {PRIVATE_APP_TAG_MAX_LENGTH} characters."
+                        ),
+                    )
+                    return ValidationResult(
+                        success=False,
+                        message=(
+                            "Each tag should be non-empty and less than or "
+                            f"equal to {PRIVATE_APP_TAG_MAX_LENGTH} "
+                            "characters."
+                        ),
+                    )
+
+            host = action.parameters.get("host", "")
+            # For a Static Host field, validate every comma-separated value
+            # at save time and fail the configuration if any value is empty
+            # or is not a valid IPv4 address, IPv4 CIDR block, hostname, or
+            # domain. For a Source field ("$" present) the validation is
+            # deferred to action execution, where invalid host values are
+            # skipped and the remaining valid values are pushed.
+            if host and "$" not in host:
+                _, skipped_hosts, skip_host_count = (
+                    self.netskope_helper.validate_hosts_for_private_app(
+                        hosts_to_push=host.split(","),
+                        private_app_name=action.parameters.get(
+                            "private_app_name", ""
+                        ),
+                    )
+                )
+                if skip_host_count > 0:
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: {skip_host_count} value(s) "
+                            "provided in the Host field are empty or are not "
+                            "a valid IPv4 address, IPv4 CIDR block, hostname, "
+                            "or domain."
+                        ),
+                        details=f"Invalid Host(s): {', '.join(skipped_hosts)}",
+                        resolution=(
+                            "Provide non-empty host values, each a valid "
+                            "IPv4 address, IPv4 CIDR block, hostname, or "
+                            "domain (max 253 characters with each label "
+                            "between 1 and 63 characters)."
+                        ),
+                    )
+                    return ValidationResult(
+                        success=False,
+                        message=(
+                            "Each host should be a non-empty valid IPv4 "
+                            "address, IPv4 CIDR block, hostname, or domain."
+                        ),
+                    )
             list_of_private_apps_list = list(existing_private_apps.keys())
             list_of_private_apps_list.append("create")
             if (
@@ -2230,10 +5549,7 @@ class NetskopePlugin(PluginBase):
                     )
 
             protocols = action.parameters.get("protocol", [])
-            if (
-                action.parameters.get("private_app_name", "") == "create"
-                and not protocols
-            ):
+            if not protocols:
                 return ValidationResult(
                     success=False,
                     message=(
@@ -2259,6 +5575,17 @@ class NetskopePlugin(PluginBase):
             ]
 
             if "TCP" in protocols:
+                # Port values only matter when the protocol is selected, so
+                # the Source-field check is scoped to this block.
+                if "$" in tcp_port:
+                    return ValidationResult(
+                        success=False,
+                        message=(
+                            "'TCP Ports' contains a Source field value. "
+                            "Please provide TCP port(s) in the Static "
+                            "field only."
+                        ),
+                    )
                 if not tcp_port_list:
                     return ValidationResult(
                         success=False,
@@ -2268,7 +5595,7 @@ class NetskopePlugin(PluginBase):
                         ),
                     )
                 if not all(
-                    self._validate_port(port) for port in tcp_port_list
+                    self.netskope_helper._validate_port(port) for port in tcp_port_list
                 ):
                     return ValidationResult(
                         success=False,
@@ -2278,6 +5605,17 @@ class NetskopePlugin(PluginBase):
                         ),
                     )
             if "UDP" in protocols:
+                # Port values only matter when the protocol is selected, so
+                # the Source-field check is scoped to this block.
+                if "$" in udp_port:
+                    return ValidationResult(
+                        success=False,
+                        message=(
+                            "'UDP Ports' contains a Source field value. "
+                            "Please provide UDP port(s) in the Static "
+                            "field only."
+                        ),
+                    )
                 if not udp_port_list:
                     return ValidationResult(
                         success=False,
@@ -2287,7 +5625,7 @@ class NetskopePlugin(PluginBase):
                         ),
                     )
                 if not all(
-                    self._validate_port(port) for port in udp_port_list
+                    self.netskope_helper._validate_port(port) for port in udp_port_list
                 ):
                     return ValidationResult(
                         success=False,
@@ -2373,6 +5711,774 @@ class NetskopePlugin(PluginBase):
             return ValidationResult(
                 success=True, message="Validation successful."
             )
+        elif action.value == "destination_profile":
+            try:
+                existing_profiles = self._get_destination_profiles()
+            except Exception as e:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Error occurred while "
+                        f"fetching destination profiles for action "
+                        f"parameter validation. Error: {e}"
+                    ),
+                    details=re.sub(
+                        r"token=([0-9a-zA-Z]*)",
+                        "token=********&",
+                        traceback.format_exc(),
+                    ),
+                )
+                return ValidationResult(success=False, message=str(e))
+            if validation_result := self._validate_parameters(
+                field_name="Operation",
+                field_value=action.parameters.get("operation", ""),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(OPERATION_OPTIONS.keys()),
+            ):
+                return validation_result
+            profile_name = action.parameters.get(
+                "destination_profile_name", ""
+            )
+            valid_profiles = list(existing_profiles.keys())
+            valid_profiles.append("create")
+            if profile_name not in valid_profiles:
+                err_msg = (
+                    "Invalid value provided for the action"
+                    " parameter 'Destination Profile'."
+                )
+                self.logger.error(
+                    message=f"{self.log_prefix}: {err_msg}",
+                    resolution=(
+                        "Select a valid Destination Profile from the"
+                        " dropdown or select 'Create new profile'."
+                    ),
+                )
+                return ValidationResult(
+                    success=False, message=err_msg
+                )
+            if profile_name == "create":
+                new_name = (
+                    action.parameters.get("new_profile_name") or ""
+                ).strip()
+                if validation_result := self._validate_parameters(
+                    field_name="Create New Profile",
+                    field_value=new_name,
+                    field_type=str,
+                    parameter_type="action",
+                    is_source_field_allowed=False,
+                ):
+                    return validation_result
+                if validation_result := self.netskope_helper._validate_max_length(
+                    field_name="Create New Profile",
+                    field_value=new_name,
+                    max_length=MAX_DESTINATION_PROFILE_NAME_LENGTH,
+                ):
+                    return validation_result
+                if validation_result := self.netskope_helper._validate_forbidden_chars(
+                    field_name="Create New Profile",
+                    field_value=new_name,
+                    forbidden_chars=DESTINATION_PROFILE_NAME_FORBIDDEN_CHARS,
+                ):
+                    return validation_result
+            new_description = (
+                action.parameters.get("new_profile_description") or ""
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Profile Description",
+                field_value=new_description,
+                field_type=str,
+                parameter_type="action",
+                is_required=False,
+                is_source_field_allowed=False,
+            ):
+                return validation_result
+            if validation_result := self.netskope_helper._validate_max_length(
+                field_name="Profile Description",
+                field_value=new_description,
+                max_length=MAX_DESTINATION_PROFILE_DESC_LENGTH,
+            ):
+                return validation_result
+            if validation_result := self._validate_parameters(
+                field_name="Match Type",
+                field_value=action.parameters.get(
+                    "profile_match_type", ""
+                ),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(MATCH_TYPE_OPTIONS.keys()),
+            ):
+                return validation_result
+            if validation_result := self._validate_parameters(
+                field_name="Apply Pending Changes",
+                field_value=action.parameters.get(
+                    "apply_pending_changes", ""
+                ),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=["Yes", "No"],
+            ):
+                return validation_result
+            destination_values = (
+                action.parameters.get("destination_values") or ""
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Network Targets",
+                field_value=destination_values,
+                field_type=str,
+                parameter_type="action",
+                check_dollar=True,
+            ):
+                return validation_result
+            # Normalize to a stripped string so the shared validator's
+            # fixed field_type check works whether the number field
+            # arrives as an int or a string; the custom check tolerates
+            # an empty value (falls back to the default) and otherwise
+            # requires a positive integer.
+            exact_total_limit = str(
+                action.parameters.get("exact_match_total_limit", "")
+            ).strip()
+            if validation_result := self._validate_parameters(
+                field_name="Tenant Exact-Match Value Limit",
+                field_value=exact_total_limit,
+                field_type=str,
+                parameter_type="action",
+                is_required=False,
+                is_source_field_allowed=False,
+                custom_validation_func=(
+                    lambda v: v == "" or (v.isdigit() and int(v) > 0)
+                ),
+            ):
+                return validation_result
+            return ValidationResult(
+                success=True, message="Validation successful."
+            )
+        elif action.value == "dns_profile":
+            try:
+                existing_profiles = self._get_dns_profiles()
+                security_categories = self._get_security_categories()
+                record_types = self._get_record_types()
+            except Exception as e:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Error occurred while "
+                        f"fetching DNS profile metadata for action "
+                        f"parameter validation. Error: {e}"
+                    ),
+                    details=re.sub(
+                        r"token=([0-9a-zA-Z]*)",
+                        "token=********&",
+                        traceback.format_exc(),
+                    ),
+                )
+                return ValidationResult(success=False, message=str(e))
+            if validation_result := self._validate_parameters(
+                field_name="Operation",
+                field_value=action.parameters.get("operation", ""),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(OPERATION_OPTIONS.keys()),
+            ):
+                return validation_result
+            if validation_result := self._validate_parameters(
+                field_name="Action Type",
+                field_value=action.parameters.get(
+                    "dns_profile_action_type", ""
+                ),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(
+                    DNS_PROFILE_ACTION_TYPE_OPTIONS.keys()
+                ),
+            ):
+                return validation_result
+            profile_value = action.parameters.get("dns_profile_name", "")
+            valid_profiles = [
+                f"{name}{CUSTOM_SEPARATOR}{profile_id}"
+                for name, profile_id in existing_profiles.items()
+            ]
+            valid_profiles.append(
+                f"Create new DNS Profile{CUSTOM_SEPARATOR}create"
+            )
+            if validation_result := self._validate_parameters(
+                field_name="DNS Profile",
+                field_value=profile_value,
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=valid_profiles,
+            ):
+                return validation_result
+            if profile_value.endswith(f"{CUSTOM_SEPARATOR}create"):
+                new_name = (
+                    action.parameters.get("new_profile_name") or ""
+                ).strip()
+                if validation_result := self._validate_parameters(
+                    field_name="Create New DNS Profile",
+                    field_value=new_name,
+                    field_type=str,
+                    parameter_type="action",
+                    is_source_field_allowed=False,
+                ):
+                    return validation_result
+                if validation_result := self.netskope_helper._validate_max_length(
+                    field_name="Create New DNS Profile",
+                    field_value=new_name,
+                    max_length=MAX_DNS_PROFILE_NAME_LENGTH,
+                ):
+                    return validation_result
+                if validation_result := self.netskope_helper._validate_forbidden_chars(
+                    field_name="Create New DNS Profile",
+                    field_value=new_name,
+                    forbidden_chars=DNS_PROFILE_FORBIDDEN_CHARS,
+                ):
+                    return validation_result
+            new_description = (
+                action.parameters.get("new_profile_description") or ""
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Profile Description",
+                field_value=new_description,
+                field_type=str,
+                parameter_type="action",
+                is_required=False,
+                is_source_field_allowed=False,
+            ):
+                return validation_result
+            if validation_result := self.netskope_helper._validate_max_length(
+                field_name="Profile Description",
+                field_value=new_description,
+                max_length=MAX_DNS_PROFILE_DESC_LENGTH,
+            ):
+                return validation_result
+            if validation_result := self.netskope_helper._validate_forbidden_chars(
+                field_name="Profile Description",
+                field_value=new_description,
+                forbidden_chars=DNS_PROFILE_FORBIDDEN_CHARS,
+            ):
+                return validation_result
+            categories = action.parameters.get(
+                "dns_security_categories", []
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Categories",
+                field_value=categories,
+                field_type=list,
+                parameter_type="action",
+                is_required=False,
+                is_source_field_allowed=False,
+                custom_validation_func=lambda cats: (
+                    isinstance(cats, list)
+                    and all(
+                        cat in security_categories for cat in cats
+                    )
+                ),
+            ):
+                return validation_result
+            category_bases = {}
+            for category in categories:
+                base = category.rsplit(" (", 1)[0]
+                category_bases.setdefault(base, set()).add(category)
+            for base, variants in category_bases.items():
+                if len(variants) > 1:
+                    err_msg = (
+                        f"Category '{base}' cannot be selected"
+                        " with both '(Block)' and '(Sinkhole)'"
+                        " actions."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {err_msg}",
+                        resolution=(
+                            f"Select either the '(Block)' or"
+                            f" '(Sinkhole)' variant of '{base}',"
+                            " not both."
+                        ),
+                    )
+                    return ValidationResult(
+                        success=False, message=err_msg
+                    )
+            has_sinkhole = any(
+                category.endswith("(Sinkhole)") for category in categories
+            )
+            sinkhole_ip = (
+                action.parameters.get("sinkhole_ip") or ""
+            ).strip()
+            if has_sinkhole:
+                if validation_result := self._validate_parameters(
+                    field_name="Sinkhole IP",
+                    field_value=sinkhole_ip,
+                    field_type=str,
+                    parameter_type="action",
+                    is_source_field_allowed=False,
+                    custom_validation_func=self.netskope_helper._validate_ip_address,
+                ):
+                    return validation_result
+            record_type_values = action.parameters.get(
+                "dns_record_types", []
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Record Types",
+                field_value=record_type_values,
+                field_type=list,
+                parameter_type="action",
+                is_required=True,
+                is_source_field_allowed=False,
+                custom_validation_func=lambda rts: all(
+                    rt in record_types for rt in rts
+                ),
+            ):
+                return validation_result
+            if (
+                "All Record Types" in record_type_values
+                and len(record_type_values) > 1
+            ):
+                err_msg = (
+                    "'All Record Types' cannot be combined"
+                    " with other record types."
+                )
+                self.logger.error(
+                    message=f"{self.log_prefix}: {err_msg}",
+                    resolution=(
+                        "Either select 'All Record Types' on its"
+                        " own or select specific record types"
+                        " without 'All Record Types'."
+                    ),
+                )
+                return ValidationResult(
+                    success=False, message=err_msg
+                )
+            if validation_result := self._validate_parameters(
+                field_name="Block all except Allow list",
+                field_value=action.parameters.get(
+                    "block_all_except_allow_list", ""
+                ),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(
+                    BLOCK_ALL_EXCEPT_ALLOW_LIST_OPTIONS.keys()
+                ),
+            ):
+                return validation_result
+            domain_names = action.parameters.get("domain_names") or ""
+            if validation_result := self._validate_parameters(
+                field_name="Domain Names",
+                field_value=domain_names,
+                field_type=str,
+                parameter_type="action",
+                check_dollar=True,
+            ):
+                return validation_result
+            return ValidationResult(
+                success=True, message="Validation successful."
+            )
+        elif action.value == "service_profile":
+            try:
+                existing_profiles = self._get_service_profiles(
+                    custom_only=True
+                )
+            except Exception as e:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Error occurred while "
+                        f"fetching service profiles for action "
+                        f"parameter validation. Error: {e}"
+                    ),
+                    details=re.sub(
+                        r"token=([0-9a-zA-Z]*)",
+                        "token=********&",
+                        traceback.format_exc(),
+                    ),
+                )
+                return ValidationResult(success=False, message=str(e))
+            if validation_result := self._validate_parameters(
+                field_name="Operation",
+                field_value=action.parameters.get("operation", ""),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(
+                    SERVICE_PROFILE_OPERATION_OPTIONS.keys()
+                ),
+            ):
+                return validation_result
+            icmp = action.parameters.get("icmp", False)
+            if icmp not in [True, False]:
+                return ValidationResult(
+                    success=False,
+                    message=(
+                        "Invalid value provided for the choice"
+                        " parameter 'ICMP'."
+                    ),
+                )
+            profile_name = action.parameters.get(
+                "service_profile_name", ""
+            )
+            valid_profiles = list(existing_profiles.keys())
+            valid_profiles.append("create")
+            if validation_result := self._validate_parameters(
+                field_name="Service Profile",
+                field_value=profile_name,
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=valid_profiles,
+            ):
+                return validation_result
+            if profile_name == "create":
+                new_name = (
+                    action.parameters.get("new_profile_name") or ""
+                ).strip()
+                if validation_result := self._validate_parameters(
+                    field_name="Service Profile Name",
+                    field_value=new_name,
+                    field_type=str,
+                    parameter_type="action",
+                    is_source_field_allowed=False,
+                ):
+                    return validation_result
+                if validation_result := self.netskope_helper._validate_max_length(
+                    field_name="Service Profile Name",
+                    field_value=new_name,
+                    max_length=MAX_SERVICE_PROFILE_NAME_LENGTH,
+                ):
+                    return validation_result
+            new_description = (
+                action.parameters.get("new_profile_description") or ""
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Description",
+                field_value=new_description,
+                field_type=str,
+                parameter_type="action",
+                is_required=False,
+                is_source_field_allowed=False,
+            ):
+                return validation_result
+            if validation_result := self.netskope_helper._validate_max_length(
+                field_name="Description",
+                field_value=new_description,
+                max_length=MAX_SERVICE_PROFILE_DESC_LENGTH,
+            ):
+                return validation_result
+            port_fields = {
+                "tcp_ports": "TCP Ports",
+                "udp_ports": "UDP Ports",
+                "tcp_udp_ports": "TCP/UDP Ports",
+            }
+            has_any_ports = False
+            for key, label in port_fields.items():
+                raw_value = action.parameters.get(key) or ""
+                if validation_result := self._validate_parameters(
+                    field_name=label,
+                    field_value=raw_value,
+                    field_type=str,
+                    parameter_type="action",
+                    is_required=False,
+                    check_dollar=True,
+                    custom_validation_func=lambda v: all(
+                        self.netskope_helper._validate_port(p)
+                        for p in [
+                            p.strip()
+                            for p in v.split(",")
+                            if p.strip()
+                        ]
+                    ),
+                ):
+                    return validation_result
+                if raw_value.strip():
+                    has_any_ports = True
+            if not has_any_ports and not icmp:
+                err_msg = (
+                    "At least one of TCP Ports, UDP Ports,"
+                    " TCP/UDP Ports, or ICMP is required."
+                )
+                self.logger.error(
+                    message=f"{self.log_prefix}: {err_msg}",
+                    resolution=(
+                        "Provide at least one port value or enable"
+                        " ICMP in the action configuration."
+                    ),
+                )
+                return ValidationResult(
+                    success=False, message=err_msg
+                )
+            return ValidationResult(
+                success=True, message="Validation successful."
+            )
+        elif action.value == "device_classification":
+            try:
+                existing_classifications = (
+                    self._get_device_classifications()
+                )
+                existing_rules = self._get_device_classification_rules()
+            except Exception as e:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Error occurred while "
+                        "fetching device classification metadata for "
+                        f"action parameter validation. Error: {e}"
+                    ),
+                    details=traceback.format_exc(),
+                )
+                return ValidationResult(success=False, message=str(e))
+            if validation_result := self._validate_parameters(
+                field_name="Operation",
+                field_value=action.parameters.get("operation", ""),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(OPERATION_OPTIONS.keys()),
+            ):
+                return validation_result
+            classification_value = action.parameters.get(
+                "device_classification", ""
+            )
+            valid_classifications = list(
+                existing_classifications.keys()
+            )
+            valid_classifications.append("create")
+            if validation_result := self._validate_parameters(
+                field_name="Device Classification",
+                field_value=classification_value,
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=valid_classifications,
+            ):
+                return validation_result
+            if classification_value == "create":
+                new_name = (
+                    action.parameters.get("new_classification_name")
+                    or ""
+                ).strip()
+                if validation_result := self._validate_parameters(
+                    field_name="Device Classification Name",
+                    field_value=new_name,
+                    field_type=str,
+                    parameter_type="action",
+                    is_source_field_allowed=False,
+                ):
+                    return validation_result
+                if validation_result := self.netskope_helper._validate_max_length(
+                    field_name="Device Classification Name",
+                    field_value=new_name,
+                    max_length=MAX_DEVICE_CLASSIFICATION_NAME_LENGTH,
+                ):
+                    return validation_result
+            rule_value = action.parameters.get(
+                "device_classification_rule", ""
+            )
+            valid_rules = [
+                f"{rule.get('name', '')}"
+                f"{CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION}"
+                f"{rule.get('id')}"
+                for rule in existing_rules
+                if rule.get("name") and rule.get("id") is not None
+            ]
+            valid_rules.append(
+                f"Create new Device Classification Rule"
+                f"{CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION}create"
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Device Classification Rule",
+                field_value=rule_value,
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=valid_rules,
+            ):
+                return validation_result
+            if rule_value.endswith(
+                f"{CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION}create"
+            ):
+                new_rule = (
+                    action.parameters.get("new_rule_name") or ""
+                ).strip()
+                if validation_result := self._validate_parameters(
+                    field_name="Device Classification Rule Name",
+                    field_value=new_rule,
+                    field_type=str,
+                    parameter_type="action",
+                    is_source_field_allowed=False,
+                ):
+                    return validation_result
+                if validation_result := self.netskope_helper._validate_max_length(
+                    field_name="Device Classification Rule Name",
+                    field_value=new_rule,
+                    max_length=MAX_DEVICE_CLASSIFICATION_NAME_LENGTH,
+                ):
+                    return validation_result
+                if CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION in new_rule:
+                    err_msg = (
+                        "'Device Classification Rule Name' should"
+                        " not contain"
+                        f" '{CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION}'."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {err_msg}",
+                        resolution=(
+                            "Remove"
+                            f" '{CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION}'"
+                            " from the 'Device Classification Rule"
+                            " Name'."
+                        ),
+                    )
+                    return ValidationResult(
+                        success=False, message=err_msg
+                    )
+            if validation_result := self._validate_parameters(
+                field_name="Operating System",
+                field_value=action.parameters.get("os", ""),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(
+                    DEVICE_CLASSIFICATION_OS_OPTIONS.keys()
+                ),
+            ):
+                return validation_result
+            if validation_result := self._validate_parameters(
+                field_name="Match Type",
+                field_value=action.parameters.get(
+                    "logical_operator", ""
+                ),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(
+                    DEVICE_CLASSIFICATION_OPERATOR_OPTIONS.keys()
+                ),
+            ):
+                return validation_result
+            if validation_result := self._validate_parameters(
+                field_name="Group Match Type",
+                field_value=action.parameters.get(
+                    "group_operator", ""
+                ),
+                field_type=str,
+                parameter_type="action",
+                is_source_field_allowed=False,
+                allowed_values=list(
+                    DEVICE_CLASSIFICATION_OPERATOR_OPTIONS.keys()
+                ),
+            ):
+                return validation_result
+            # Tags are required. Static tags are validated to exist on
+            # the Netskope Tenant at save; Source fields ("$") are
+            # resolved and validated at execution time instead.
+            raw_tags = (
+                action.parameters.get("classification_tags") or ""
+            )
+            if validation_result := self._validate_parameters(
+                field_name="Tags",
+                field_value=raw_tags,
+                field_type=str,
+                parameter_type="action",
+                check_dollar=True,
+            ):
+                return validation_result
+            if "$" not in raw_tags:
+                raw_segments = raw_tags.split(",")
+                tag_list = [
+                    tag.strip()
+                    for tag in raw_segments
+                    if tag.strip()
+                ]
+                if any(not tag.strip() for tag in raw_segments):
+                    err_msg = (
+                        "'Tags' should not contain empty values"
+                        " between commas."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {err_msg}",
+                        resolution=(
+                            "Provide a non-empty tag name between"
+                            " each comma in the 'Tags' field."
+                        ),
+                    )
+                    return ValidationResult(
+                        success=False, message=err_msg
+                    )
+                # Short-circuit: any tag that violates Netskope's
+                # tag-creation constraints can never exist on the
+                # tenant, so fail immediately without making an API
+                # call to _fetch_all_tags.
+                invalid_chars = [
+                    tag for tag in tag_list
+                    if not re.match(REGEX_TAG, tag)
+                ]
+                if invalid_chars:
+                    err_msg = (
+                        "One or more Tags contain invalid characters"
+                        " and cannot exist on the Netskope Tenant."
+                        " Tag names must contain only alphanumeric"
+                        " characters, hyphens, and spaces."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {err_msg}",
+                        resolution=(
+                            "Provide tag names that contain only"
+                            " alphanumeric characters, hyphens, and"
+                            " spaces."
+                        ),
+                    )
+                    return ValidationResult(
+                        success=False, message=err_msg
+                    )
+                for tag in tag_list:
+                    if validation_result := self.netskope_helper._validate_max_length(
+                        field_name=f"Tag '{tag}'",
+                        field_value=tag,
+                        max_length=TAG_DEVICE_TAG_LENGTH,
+                    ):
+                        return validation_result
+                try:
+                    tag_cache = self._fetch_all_tags()
+                except Exception as e:
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: Error occurred while "
+                            "fetching device tags for action parameter "
+                            f"validation. Error: {e}"
+                        ),
+                        details=traceback.format_exc(),
+                    )
+                    return ValidationResult(
+                        success=False, message=str(e)
+                    )
+                missing = [
+                    tag
+                    for tag in tag_list
+                    if tag.lower() not in tag_cache
+                ]
+                if missing:
+                    err_msg = (
+                        "Some of the provided Tags do not exist on"
+                        " the Netskope Tenant. Provide existing"
+                        " device tags."
+                    )
+                    self.logger.error(
+                        message=f"{self.log_prefix}: {err_msg}",
+                        details=(
+                            "Tags not found on the Netskope Tenant: "
+                            f"{', '.join(missing)}."
+                        ),
+                        resolution=(
+                            "Ensure all provided tag names exist on"
+                            " the Netskope Tenant before saving."
+                        ),
+                    )
+                    return ValidationResult(
+                        success=False, message=err_msg
+                    )
+            return ValidationResult(
+                success=True, message="Validation successful."
+            )
         return ValidationResult(
             success=False, message="Invalid action provided."
         )
@@ -2429,7 +6535,11 @@ class NetskopePlugin(PluginBase):
                     f"{self.log_prefix}: {error_message} "
                     f"Error: {err}"
                 ),
-                details=str(traceback.format_exc()),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
             )
             raise NetskopeException(error_message)
         self.logger.debug(
@@ -2462,7 +6572,19 @@ class NetskopePlugin(PluginBase):
         url = (
             f"{tenant_name}{URLS.get('V2_PRIVATE_APP')}"
         )
-        params = {"fields": "app_id,app_name,host"}  # we need only 3 fields
+        # tags / protocols / publishers / use_publisher_dns are needed only
+        # when resolving a group for a push (get_hosts_of set): the Append
+        # path unions the new tags with the app's existing tags, and the
+        # metadata-refresh path compares these fields against the action
+        # params to skip no-op update calls. The dropdown/validate calls do
+        # not need them.
+        fields = "app_id,app_name,host"
+        if get_hosts_of:
+            fields += (
+                ",tags,protocols,service_publisher_assignments,"
+                "use_publisher_dns"
+            )
+        params = {"fields": fields}
         logger_msg = "fetching private apps on the Netskope Tenant"
         self.logger.debug(
             f"{self.log_prefix}: {logger_msg.capitalize()}."
@@ -2486,8 +6608,20 @@ class NetskopePlugin(PluginBase):
                 dict_of_private_apps[x["app_name"]] = {
                     "id": x["app_id"],
                     "host_count": len(x["host"].split(",")),
+                    "tags": self.netskope_helper._extract_private_app_tag_names(
+                        x.get("tags", [])
+                    ),
                 } | (
-                    {"hosts": x["host"].split(",")}
+                    {
+                        "hosts": x["host"].split(","),
+                        "protocols": x.get("protocols", []),
+                        "publishers": x.get(
+                            "service_publisher_assignments", []
+                        ),
+                        "use_publisher_dns": x.get(
+                            "use_publisher_dns", False
+                        ),
+                    }
                     if get_hosts_of
                     and x["app_name"].startswith(
                         get_hosts_of.removesuffix("]")
@@ -2503,7 +6637,11 @@ class NetskopePlugin(PluginBase):
                     f"{self.log_prefix}: {error_message} "
                     f"Error: {err}"
                 ),
-                details=str(traceback.format_exc()),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
             )
             raise NetskopeException(error_message)
         self.logger.debug(
@@ -2511,74 +6649,6 @@ class NetskopePlugin(PluginBase):
             f"{len(dict_of_private_apps)} private app(s)."
         )
         return dict_of_private_apps
-
-    def _get_private_app(
-        self,
-        prefix: str,
-        has_host: Optional[str] = None,
-    ) -> Union[dict, tuple]:
-        """Check private app present in Netskope and \
-            create a new one if not found.
-
-        Args:
-            prefix (str): Private app name.
-            has_host (str): Private app name.
-
-        Returns:
-            Dict: Dictionary of private apps.
-        """
-        tenant_name = (
-            self.tenant.parameters.get('tenantName', '').strip()
-        )
-        headers = {
-            "Netskope-API-Token": resolve_secret(
-                self.tenant.parameters.get("v2token", "")
-            )
-        }
-        url = (
-            f"{tenant_name}{URLS.get('V2_PRIVATE_APP')}"
-        )
-        params = {"fields": "app_id,app_name,host"}  # we need only 3 fields
-        logger_msg = "fetching private apps on the Netskope Tenant"
-        self.logger.debug(
-            f"{self.log_prefix}: {logger_msg.capitalize()}."
-        )
-        try:
-            response = self.netskope_helper._api_call_helper(
-                url=url,
-                method="get",
-                error_codes=["CRE_1040", "CRE_1041"],
-                headers=headers,
-                params=params,
-                proxies=self.proxy,
-                message=f"Error occurred while {logger_msg}",
-                logger_msg=logger_msg,
-            )
-
-            existing_private_apps = response.get("data", {}).get(
-                "private_apps", []
-            )
-            # Private app from netskope.
-            for app in existing_private_apps:
-                split_hosts = app.get("host", "").split(",")
-                if not app["app_name"].startswith(prefix.removesuffix("]")):
-                    continue
-                if has_host not in split_hosts:
-                    continue
-                return app
-        except NetskopeException:
-            raise
-        except Exception as err:
-            error_message = f"Error occurred while {logger_msg}."
-            self.logger.error(
-                message=(
-                    f"{self.log_prefix}: {error_message} "
-                    f"Error: {err}"
-                ),
-                details=str(traceback.format_exc()),
-            )
-            raise NetskopeException(error_message)
-        return None
 
     def get_action_params(self, action: Action) -> list:
         """Get fields required for an action.
@@ -2736,6 +6806,27 @@ class NetskopePlugin(PluginBase):
             existing_private_apps = self._get_private_apps()
             existing_publishers = self._get_publishers()
             return [
+                {
+                    "label": "Skip Excess Hosts",
+                    "key": "skip_excess_hosts",
+                    "type": "choice",
+                    "choices": [
+                        {"key": "No", "value": False},
+                        {"key": "Yes", "value": True},
+                    ],
+                    "default": False,
+                    "mandatory": True,
+                    "description": (
+                        "A private app holds at most "
+                        f"{MAX_HOSTS_PER_PRIVATE_APP} hosts. Select 'No' to "
+                        "create roll-over sibling private apps until all "
+                        "hosts are accommodated or the tenant's private app "
+                        "limit is reached (the rest are skipped). Select "
+                        "'Yes' to not create roll-over siblings and skip "
+                        "any hosts beyond the existing capacity. Select "
+                        "from the Static field dropdown only."
+                    ),
+                },
                 {
                     "label": "Host",
                     "key": "host",
@@ -3078,6 +7169,131 @@ class NetskopePlugin(PluginBase):
                     "description": "Select Tag from Static field dropdown.",
                 },
             ]
+        elif action.value == "destination_profile":
+            existing_profiles = self._get_destination_profiles()
+            params = copy.deepcopy(DESTINATION_PROFILE_ACTION_PARAMS)
+            profile_choices = [
+                {"key": key, "value": key}
+                for key in sorted(existing_profiles.keys())
+            ] + [
+                {"key": "Create new profile", "value": "create"}
+            ]
+            for param in params:
+                if param["key"] == "destination_profile_name":
+                    param["choices"] = profile_choices
+            return params
+        elif action.value == "dns_profile":
+            existing_profiles = self._get_dns_profiles()
+            security_categories = self._get_security_categories()
+            record_types = self._get_record_types()
+            profile_choices = [
+                {
+                    "key": name,
+                    "value": f"{name}{CUSTOM_SEPARATOR}{profile_id}",
+                }
+                for name, profile_id in sorted(
+                    existing_profiles.items(),
+                    key=lambda item: item[0].lower(),
+                )
+            ] + [
+                {
+                    "key": "Create new DNS Profile",
+                    "value": (
+                        f"Create new DNS Profile"
+                        f"{CUSTOM_SEPARATOR}create"
+                    ),
+                }
+            ]
+            params = copy.deepcopy(DNS_PROFILE_ACTION_PARAMS)
+            for param in params:
+                key = param["key"]
+                if key == "dns_profile_name":
+                    param["choices"] = profile_choices
+                    param["default"] = (
+                        profile_choices[0]["value"]
+                        if profile_choices
+                        else ""
+                    )
+                elif key == "dns_security_categories":
+                    param["choices"] = [
+                        {"key": category, "value": category}
+                        for category in security_categories
+                    ]
+                elif key == "dns_record_types":
+                    param["choices"] = [
+                        {"key": record_type, "value": record_type}
+                        for record_type in record_types
+                    ]
+                    param["default"] = (
+                        [record_types[0]] if record_types else []
+                    )
+            return params
+        elif action.value == "service_profile":
+            existing_profiles = self._get_service_profiles(
+                custom_only=True
+            )
+            params = copy.deepcopy(SERVICE_PROFILE_ACTION_PARAMS)
+            profile_choices = [
+                {"key": key, "value": key}
+                for key in sorted(existing_profiles.keys())
+            ] + [
+                {
+                    "key": "Create new service profile",
+                    "value": "create",
+                }
+            ]
+            for param in params:
+                if param["key"] == "service_profile_name":
+                    param["choices"] = profile_choices
+            return params
+        elif action.value == "device_classification":
+            existing_classifications = (
+                self._get_device_classifications()
+            )
+            existing_rules = self._get_device_classification_rules()
+            classification_choices = [
+                {"key": name, "value": name}
+                for name in sorted(
+                    existing_classifications.keys(),
+                    key=lambda n: n.lower(),
+                )
+            ] + [
+                {
+                    "key": "Create new Device Classification",
+                    "value": "create",
+                }
+            ]
+            rule_choices = [
+                {
+                    "key": rule.get("name", ""),
+                    "value": (
+                        f"{rule.get('name', '')}"
+                        f"{CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION}"
+                        f"{rule.get('id')}"
+                    ),
+                }
+                for rule in sorted(
+                    existing_rules,
+                    key=lambda r: str(r.get("name", "")).lower(),
+                )
+                if rule.get("name") and rule.get("id") is not None
+            ] + [
+                {
+                    "key": "Create new Device Classification Rule",
+                    "value": (
+                        f"Create new Device Classification Rule"
+                        f"{CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION}create"
+                    ),
+                }
+            ]
+            params = copy.deepcopy(DEVICE_CLASSIFICATION_ACTION_PARAMS)
+            for param in params:
+                key = param["key"]
+                if key == "device_classification":
+                    param["choices"] = classification_choices
+                elif key == "device_classification_rule":
+                    param["choices"] = rule_choices
+            return params
         return []
 
     def _push_private_app(
@@ -3092,204 +7308,161 @@ class NetskopePlugin(PluginBase):
         use_publisher_dns: bool,
         default_url: str,
         tags: list[str] = [],
+        skip_excess_hosts: bool = False,
+        host_to_tags: Optional[dict] = None,
+        compact: bool = False,
     ):
-        """Push a private app to Netskope with the provided indicators, \
-            app names, protocols, and publishers.
+        """Append host(s) to a private app group.
+
+        Resolves the logical private app (the base app ``[X]`` plus any
+        numbered roll-over siblings ``[X 2]`` ...), runs the shared setup
+        (protocols, publishers, host/tag validation, group enumeration),
+        then appends the hosts via ``_append_private_app_hosts`` (honouring
+        the per-app host cap ``MAX_HOSTS_PER_PRIVATE_APP`` and
+        ``skip_excess_hosts``). When ``compact`` is set (bulk sync only) the
+        group is consolidated after the append to reclaim apps left
+        partially filled by earlier reverts.
 
         Args:
-            host (Union[str, list[str]]): The host to be pushed.
-            existing_private_app_name (str): The name of an \
-                existing private app.
-            new_private_app_name (str): The name of a new private app.
+            host (Union[str, list[str]]): The host(s) to be shared.
+            existing_private_app_name (str): Selected app name, or
+                ``create``.
+            new_private_app_name (str): Name for a newly created app.
             protocol_type (List[str]): The list of protocol types.
             tcp_ports (List[int]): The list of TCP ports.
             udp_ports (List[int]): The list of UDP ports.
             publishers (List[str]): The list of publishers.
-            use_publisher_dns (bool): A boolean indicating whether \
-                to use the publisher DNS.
+            use_publisher_dns (bool): Whether to use the publisher DNS.
             default_url (str): The default host.
             tags (List[str], optional): The list of tags. Defaults to [].
+            skip_excess_hosts (bool, optional): When True, do not create \
+                new roll-over sibling apps for hosts beyond the existing \
+                capacity - the excess hosts are skipped. When False, new \
+                siblings are created until all hosts fit or the tenant's \
+                private app limit is reached. Defaults to False.
+            host_to_tags (Optional[dict], optional): Pre-built and \
+                pre-validated ``{host -> set(tag_name)}`` map used to scope \
+                each app's tags to the records whose hosts land in it \
+                (bulk path). When None (single/fallback), it is built from \
+                ``tags`` and applied uniformly to all hosts. Defaults None.
+            compact (bool, optional): When True (set by the bulk sync), \
+                consolidate the app group after the append so apps left \
+                partially filled by earlier reverts are re-packed and any \
+                emptied trailing apps removed. Best-effort. Defaults False.
+
+        Returns:
+            tuple[set[str], dict[str, int]]: ``(not_placed, added_counts)``
+                where ``not_placed`` is the set of host values that were
+                NOT placed (invalid plus capacity-skipped), used by
+                ``execute_actions`` to attribute failed action ids per
+                record, and ``added_counts`` maps each private app name to
+                the number of hosts added to it.
         """
         tenant_name = (
             self.tenant.parameters.get('tenantName', '').strip()
         )
-        headers = {
-            "Netskope-API-Token": resolve_secret(
-                self.tenant.parameters.get("v2token", "")
-            )
-        }
-
         try:
             if existing_private_app_name == "create":
-                private_app_name = f"[{new_private_app_name}]"
+                base_name = new_private_app_name
             else:
-                private_app_name = existing_private_app_name
+                base_name = existing_private_app_name.removeprefix(
+                    "["
+                ).removesuffix("]")
+            private_app_name = f"[{base_name}]"
+            # Validate/filter the hosts first (no API calls): if nothing is
+            # valid we can short-circuit before the fetch-apps /
+            # fetch-publishers calls below, which would otherwise be wasted.
+            if host and isinstance(host, str):
+                host = list(map(lambda x: x.strip(), host.split(",")))
+            if host_to_tags is None:
+                # Single-record / fallback: validate the uniform tags and
+                # map every valid host to the same tag-name set.
+                valid_hosts, valid_tags, invalid_hosts = (
+                    self._filter_private_app_hosts_tags(
+                        host if host else [], tags, private_app_name
+                    )
+                )
+                tag_names = {tag["tag_name"] for tag in valid_tags}
+                host_to_tags = {
+                    valid_host: set(tag_names) for valid_host in valid_hosts
+                }
+            else:
+                # Bulk: tags were validated + attached per record upstream;
+                # only the hosts need validating here.
+                valid_hosts, _, invalid_hosts = (
+                    self._filter_private_app_hosts_tags(
+                        host if host else [], [], private_app_name
+                    )
+                )
+            # De-duplicate while keeping a deterministic order.
+            unique_hosts = list(dict.fromkeys(valid_hosts))
+            if not unique_hosts:
+                # Append has nothing to add - skip without the fetch-apps /
+                # fetch-publishers calls below. Every record in this group
+                # contributed only invalid/empty hosts, so returning them as
+                # not-placed fails all those records.
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: No valid host to add to "
+                        f"private app '{private_app_name}'; hence"
+                        " skipping the action."
+                    ),
+                    resolution=(
+                        "Provide at least one valid host (IPv4 "
+                        "address, IPv4 CIDR block, hostname, or "
+                        "domain)."
+                    ),
+                )
+                return set(invalid_hosts), {}
             existing_private_apps = self._get_private_apps(
                 get_hosts_of=private_app_name
             )
-            final_name = private_app_name
-            counter = 2
-            while True:
-                if final_name not in existing_private_apps:
-                    existing_private_app_name = final_name.removeprefix(
-                        "["
-                    ).removesuffix("]")
-                    break
-                if (
-                    existing_private_apps[final_name].get("host_count", 0)
-                    < MAX_HOSTS_PER_PRIVATE_APP
-                ):
-                    break
-                final_name = f"[{private_app_name.removeprefix('[').removesuffix(']')} {counter}]"
-                counter += 1
-            private_app_name = final_name
-            existing_publishers = self._get_publishers()
-            protocols_list = []
-            for protocol in protocol_type:
-                if protocol == "TCP":
-                    protocols_list.append(
-                        {"type": "tcp", "ports": ",".join(tcp_ports)}
-                    )
-                if protocol == "UDP":
-                    protocols_list.append(
-                        {"type": "udp", "ports": ",".join(udp_ports)}
-                    )
-
-            publishers_list = []
-            skipped_publishers = []
-            for publisher in publishers:
-                if publisher in existing_publishers:
-                    publishers_list.append(
-                        {
-                            "publisher_id": existing_publishers[publisher],
-                            "publisher_name": publisher,
-                        }
-                    )
-                else:
-                    skipped_publishers.append(publisher)
-
-            if not publishers_list and skipped_publishers:
-                self.logger.error(
-                    f"{self.log_prefix}: Unable to find the "
-                    f"provided publishers [{','.join(skipped_publishers)}]."
-                )
-                raise NetskopeException(
-                    f"{self.log_prefix}: Could not create new private app "
-                    "to share host."
-                )
-
-            if skipped_publishers:
-                self.logger.error(
-                    f"{self.log_prefix}: Unable to find the following "
-                    f"publishers [{','.join(skipped_publishers)}]."
-                    " Hence ignoring them while creating "
-                    f"the private app '{private_app_name}'."
-                )
-            # Check if the private app already exists
-            if private_app_name not in existing_private_apps:
-                # Creating URL List
-                self.logger.debug(
-                    f"{self.log_prefix}: Private app '{private_app_name}' "
-                    "does not exist. Creating a new private app."
-                )
-
-                if existing_private_app_name == "create":
-                    app_name_to_create = new_private_app_name
-                else:
-                    app_name_to_create = existing_private_app_name
-
-                data = {
-                    "app_name": app_name_to_create,
-                    "host": default_url,
-                    "publishers": publishers_list,
-                    "use_publisher_dns": use_publisher_dns,
-                }
-                if protocols_list:
-                    data["protocols"] = protocols_list
-                logger_msg = "creating private app on the Netskope Tenant"
-                url = (
-                    f"{tenant_name}{URLS.get('V2_PRIVATE_APP')}"
-                )
-                response = self.netskope_helper._api_call_helper(
-                    url=url,
-                    method="post",
-                    error_codes=["CRE_1043", "CRE_1044"],
-                    headers=headers,
-                    json=data,
-                    proxies=self.proxy,
-                    message=f"Error occurred while {logger_msg}",
-                    logger_msg=logger_msg,
-                    is_handle_error_required=False
-                )
-
-                if response.status_code not in [
-                    200,
-                    201,
-                ]:
-                    err_msg = (
-                        f"Error occurred while {logger_msg}. "
-                    )
-                    self.logger.error(
-                        message=err_msg,
-                        details=str(response.text),
-                    )
-                    raise NetskopeException(
-                        "Could not create new private app to share host.",
-                    )
-                create_private_app_json = handle_status_code(
-                    response,
-                    error_code="CRE_1044",
-                    custom_message=f"Error occurred while {logger_msg}.",
-                    plugin=self.log_prefix,
-                    notify=False,
-                    log=True,
-                )
-
-                if create_private_app_json.get("status", "") != "success":
-                    self.logger.error(
-                        message=(
-                            f"{self.log_prefix}: Error occurred while "
-                            "creating private app. "
-                            f"Received exit code {response.status_code}."
-                        ),
-                        details=repr(create_private_app_json),
-                    )
-                    raise NetskopeException(
-                        "Could not create new private app to share the host."
-                    )
-
-                existing_private_apps[
-                    create_private_app_json["data"]["app_name"]
-                ] = {
-                    "id": create_private_app_json["data"]["app_id"],
-                    "host_count": 0,
-                    "hosts": [],
-                }
-
-            if host and isinstance(host, str):
-                host = list(map(lambda x: x.strip(), host.split(",")))
-            data = {
-                "host": ",".join(
-                    list(
-                        set(
-                            existing_private_apps[private_app_name].get(
-                                "hosts", []
-                            )
-                        ).union(host)
-                    )
-                ),
-                "tags": (
-                    list(map(lambda t: {"tag_name": t}, tags)) if tags else []
-                ),
-                "publishers": publishers_list,
+            protocols_list = self.netskope_helper._build_private_app_protocols(
+                protocol_type, tcp_ports, udp_ports
+            )
+            publishers_list = self._resolve_private_app_publishers(
+                publishers, private_app_name
+            )
+            members = self.netskope_helper._ordered_private_app_group(
+                existing_private_apps, base_name
+            )
+            shared = {
+                "tenant_name": tenant_name,
+                "base_name": base_name,
+                "private_app_name": private_app_name,
+                "members": members,
+                "host_to_tags": host_to_tags,
+                "publishers_list": publishers_list,
                 "use_publisher_dns": use_publisher_dns,
+                "protocols_list": protocols_list,
+                "default_url": default_url,
+                "skip_excess_hosts": skip_excess_hosts,
             }
-            if protocols_list:
-                data["protocols"] = protocols_list
-            return self._patch_private_app(
-                tenant_name,
-                existing_private_apps[private_app_name].get("id", ""),
-                data,
+            capacity_skipped, added_counts = (
+                self._append_private_app_hosts(unique_hosts, **shared)
+            )
+            # After the append, consolidate the group (bulk sync only): an
+            # earlier revert may have left apps partially filled, so re-pack
+            # the group to free up trailing apps. Best-effort - a compaction
+            # failure is logged but never fails the action.
+            if compact:
+                self._compact_private_app_group(
+                    tenant_name,
+                    base_name,
+                    private_app_name,
+                    host_to_tags,
+                    publishers_list,
+                    use_publisher_dns,
+                    protocols_list,
+                    default_url,
+                )
+            # Hosts that were not placed: invalid (validation-filtered) plus
+            # capacity-skipped (Skip Excess / tenant limit). The caller uses
+            # this to attribute failed action ids per record, and
+            # added_counts (app name -> hosts added) for the final summary.
+            return (
+                set(invalid_hosts) | set(capacity_skipped or []),
+                added_counts,
             )
         except NetskopeException:
             raise
@@ -3310,6 +7483,820 @@ class NetskopePlugin(PluginBase):
                 error_code="CRE_1021",
             )
             raise NetskopeException(error_message)
+
+    def _resolve_private_app_publishers(self, publishers, private_app_name):
+        """Resolve publisher names to private app publisher entries.
+
+        Unknown publishers are skipped and logged; if every provided
+        publisher is unknown a NetskopeException is raised.
+
+        Args:
+            publishers (list[str]): Publisher names selected for the app.
+            private_app_name (str): Target app name (used in logs).
+
+        Returns:
+            list[dict]: ``{publisher_id, publisher_name}`` entries.
+        """
+        existing_publishers = self._get_publishers()
+        publishers_list = []
+        skipped_publishers = []
+        for publisher in publishers:
+            if publisher in existing_publishers:
+                publishers_list.append(
+                    {
+                        "publisher_id": existing_publishers[publisher],
+                        "publisher_name": publisher,
+                    }
+                )
+            else:
+                skipped_publishers.append(publisher)
+        if not publishers_list and skipped_publishers:
+            self.logger.error(
+                f"{self.log_prefix}: Unable to find the "
+                f"provided publishers [{','.join(skipped_publishers)}]."
+            )
+            raise NetskopeException(
+                f"{self.log_prefix}: Could not create new private app "
+                "to share host."
+            )
+        if skipped_publishers:
+            self.logger.error(
+                f"{self.log_prefix}: Unable to find the following "
+                f"publishers [{','.join(skipped_publishers)}]."
+                " Hence ignoring them while creating "
+                f"the private app '{private_app_name}'."
+            )
+        return publishers_list
+
+    def _filter_private_app_hosts_tags(self, host, tags, private_app_name):
+        """Validate and sanitize hosts and tags before sharing.
+
+        Invalid hosts (empty or not a valid IPv4 address, IPv4 CIDR
+        block, hostname, or domain) and invalid tags (empty or over the
+        maximum length) are skipped and logged. Static values are
+        already validated at save time; this mainly covers Source-field
+        values resolved per record at execution.
+
+        Args:
+            host (list[str]): Hosts to validate.
+            tags (list[str]): Tags to validate.
+            private_app_name (str): Target app name (used in logs).
+
+        Returns:
+            tuple[list[str], list[dict], list[str]]: (valid_hosts,
+                valid_tags, skipped_hosts) where ``skipped_hosts`` are the
+                invalid (not-placed) host values, used for per-record
+                failed-action-id attribution.
+        """
+        valid_hosts, skipped_hosts, skip_host_count = (
+            self.netskope_helper.validate_hosts_for_private_app(
+                hosts_to_push=host if host else [],
+                private_app_name=private_app_name,
+            )
+        )
+        if skip_host_count > 0:
+            self.logger.info(
+                message=(
+                    f"{self.log_prefix}: Skipped adding "
+                    f"{skip_host_count} host(s) to private app "
+                    f"'{private_app_name}' as they were empty or were "
+                    "not a valid IPv4 address, IPv4 CIDR block, "
+                    "hostname, or domain."
+                ),
+                details=f"Skipped Host(s): {', '.join(skipped_hosts)}",
+            )
+        valid_tags, skipped_tags, skip_tag_count = (
+            self.netskope_helper.validate_tags_for_private_app(
+                tags_to_push=tags,
+                private_app_name=private_app_name,
+            )
+        )
+        if skip_tag_count > 0:
+            self.logger.info(
+                message=(
+                    f"{self.log_prefix}: Skipped adding "
+                    f"{skip_tag_count} tag(s) to private app "
+                    f"'{private_app_name}' as they were empty or "
+                    "exceeded the maximum allowed character limit of "
+                    f"{PRIVATE_APP_TAG_MAX_LENGTH}."
+                ),
+                details=f"Skipped Tags: {', '.join(skipped_tags)}",
+            )
+        return valid_hosts, valid_tags, skipped_hosts
+
+    def _create_private_app(
+        self,
+        app_name_to_create,
+        default_url,
+        publishers_list,
+        use_publisher_dns,
+        protocols_list,
+    ):
+        """Create a private app seeded with the default host.
+
+        Args:
+            app_name_to_create (str): Name to create the app with.
+            default_url (str): Seed host for the new app.
+            publishers_list (list[dict]): Resolved publisher entries.
+            use_publisher_dns (bool): Whether to use the publisher DNS.
+            protocols_list (list[dict]): Protocol entries for the app.
+
+        Returns:
+            tuple[str, str]: (app_id, app_name) of the created app.
+
+        Raises:
+            NetskopeException: If the app could not be created.
+        """
+        tenant_name = (
+            self.tenant.parameters.get('tenantName', '').strip()
+        )
+        headers = {
+            "Netskope-API-Token": resolve_secret(
+                self.tenant.parameters.get("v2token", "")
+            )
+        }
+        data = {
+            "app_name": app_name_to_create,
+            "host": default_url,
+            "publishers": publishers_list,
+            "use_publisher_dns": use_publisher_dns,
+        }
+        if protocols_list:
+            data["protocols"] = protocols_list
+        logger_msg = (
+            f"creating private app '{app_name_to_create}' on the "
+            "Netskope Tenant"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
+        url = f"{tenant_name}{URLS.get('V2_PRIVATE_APP')}"
+        response = self.netskope_helper._api_call_helper(
+            url=url,
+            method="post",
+            error_codes=["CRE_1043", "CRE_1044"],
+            headers=headers,
+            json=data,
+            proxies=self.proxy,
+            message=f"Error occurred while {logger_msg}",
+            logger_msg=logger_msg,
+            is_handle_error_required=False,
+        )
+        if response.status_code not in [200, 201]:
+            err_msg = f"Error occurred while {logger_msg}. "
+            self.logger.error(
+                message=err_msg,
+                details=str(response.text),
+            )
+            raise NetskopeException(
+                "Could not create new private app to share host.",
+            )
+        create_private_app_json = handle_status_code(
+            response,
+            error_code="CRE_1044",
+            custom_message=f"Error occurred while {logger_msg}.",
+            plugin=self.log_prefix,
+            notify=False,
+            log=True,
+        )
+        if create_private_app_json.get("status", "") != "success":
+            response_message = create_private_app_json.get("message", "")
+            # The tenant's max private app count returns HTTP 200 with a
+            # status=error body; treat it as a non-fatal stop signal so the
+            # roll-over can skip the remaining hosts instead of failing.
+            if "maximum number" in response_message.lower():
+                raise PrivateAppLimitReachedError(response_message)
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Error occurred while "
+                    "creating private app. "
+                    f"Received exit code {response.status_code}."
+                ),
+                details=repr(create_private_app_json),
+            )
+            raise NetskopeException(
+                "Could not create new private app to share the host."
+            )
+        return (
+            create_private_app_json["data"]["app_id"],
+            create_private_app_json["data"]["app_name"],
+        )
+
+    def _delete_private_app(self, tenant_name, app_id, app_name):
+        """Delete a private app by id.
+
+        Args:
+            tenant_name (str): Tenant base URL.
+            app_id (str): Id of the app to delete.
+            app_name (str): Name of the app (used in logs).
+
+        Returns:
+            bool: True if the app was deleted, False otherwise.
+        """
+        logger_msg = f"deleting the surplus private app '{app_name}'"
+        url = (
+            f"{tenant_name}"
+            f"{URLS.get('V2_PRIVATE_APP_PATCH').format(app_id)}"
+        )
+        headers = {
+            "Netskope-API-Token": resolve_secret(
+                self.tenant.parameters.get("v2token", "")
+            )
+        }
+        try:
+            response = self.netskope_helper._api_call_helper(
+                url=url,
+                method="delete",
+                error_codes=["CRE_1069", "CRE_1070"],
+                headers=headers,
+                proxies=self.proxy,
+                message=f"Error occurred while {logger_msg}",
+                logger_msg=logger_msg,
+                is_handle_error_required=False,
+            )
+            if response.status_code in [200, 201, 204]:
+                self.logger.info(
+                    f"{self.log_prefix}: Successfully deleted the surplus "
+                    f"private app '{app_name}'."
+                )
+                return True
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Unable to delete the surplus "
+                    f"private app '{app_name}'. Received exit code "
+                    f"{response.status_code}."
+                ),
+                details=str(response.text),
+            )
+            return False
+        except Exception as err:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Error occurred while "
+                    f"{logger_msg}. Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            return False
+
+    def _remove_surplus_private_app(
+        self,
+        tenant_name,
+        member,
+        publishers_list,
+        use_publisher_dns,
+        protocols_list,
+        default_url,
+    ):
+        """Remove a private app left empty after a Replace re-pack.
+
+        Tries to delete the app; if the tenant rejects the delete (for
+        example because the app is still referenced by a policy) the app
+        is reset to the default host instead so it no longer holds stale
+        data (a private app must keep at least one host, so the default
+        host placeholder is used rather than an empty host list).
+
+        Args:
+            tenant_name (str): Tenant base URL.
+            member (dict): ``{name, id, number}`` of the surplus app.
+            publishers_list (list[dict]): Resolved publisher entries.
+            use_publisher_dns (bool): Whether to use the publisher DNS.
+            protocols_list (list[dict]): Protocol entries for the app.
+            default_url (str): Default host placeholder to reset the app to.
+
+        Returns:
+            bool: True if the app was deleted or reset.
+        """
+        if self._delete_private_app(
+            tenant_name, member["id"], member["name"]
+        ):
+            return True
+        self.logger.info(
+            f"{self.log_prefix}: Could not delete the surplus private app "
+            f"'{member['name']}'. Resetting it to the default host instead."
+        )
+        data = {
+            "host": default_url,
+            "publishers": publishers_list,
+            "use_publisher_dns": use_publisher_dns,
+        }
+        if protocols_list:
+            data["protocols"] = protocols_list
+        try:
+            self._patch_private_app(
+                tenant_name, member["id"], data, member["name"]
+            )
+            return True
+        except Exception as err:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Unable to reset the surplus "
+                    f"private app '{member['name']}'. It may still hold "
+                    f"stale hosts. Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
+            return False
+
+    def _create_overflow_siblings(
+        self,
+        tenant_name,
+        base_name,
+        members,
+        overflow_hosts,
+        skip_excess_hosts,
+        default_url,
+        host_to_tags,
+        publishers_list,
+        use_publisher_dns,
+        protocols_list,
+    ):
+        """Place overflow hosts into newly created roll-over sibling apps.
+
+        Used by both Append and Replace for the hosts that do not fit in
+        the existing group apps. New siblings are numbered past the highest
+        existing member (or named ``[base]`` when the group is empty),
+        ``MAX_HOSTS_PER_PRIVATE_APP`` hosts each.
+
+        Returns:
+            tuple[list[str], dict[str, int]]: ``(not_placed, added_counts)``
+                where ``not_placed`` is the list of hosts that could NOT be
+                placed - the hosts beyond the base app when
+                ``skip_excess_hosts`` is set (the base app is the primary
+                app, not a roll-over sibling, so it is still created), or
+                the remainder once the tenant's private app limit is
+                reached - and ``added_counts`` maps each newly created app
+                name to the number of hosts added to it.
+        """
+        if not overflow_hosts:
+            return [], {}
+        added_counts = {}
+        chunks = [
+            overflow_hosts[index: index + MAX_HOSTS_PER_PRIVATE_APP]
+            for index in range(
+                0, len(overflow_hosts), MAX_HOSTS_PER_PRIVATE_APP
+            )
+        ]
+        next_number = (
+            max(member["number"] for member in members) + 1
+            if members
+            else 2
+        )
+        # When the group is empty the first app created is the base app
+        # (the primary app, not a roll-over sibling); it is created even
+        # when skip_excess_hosts is set. Only additional siblings are
+        # gated by skip_excess_hosts.
+        base_needed = not members
+        for index, chunk in enumerate(chunks):
+            is_base = base_needed and index == 0
+            if skip_excess_hosts and not is_base:
+                remaining = [
+                    host for batch in chunks[index:] for host in batch
+                ]
+                self.logger.info(
+                    f"{self.log_prefix}: 'Skip Excess Hosts' is enabled; "
+                    f"skipping {len(remaining)} excess host(s) that "
+                    f"exceed the capacity of the existing private app(s) "
+                    f"for '[{base_name}]'."
+                )
+                return remaining, added_counts
+            if is_base:
+                sibling_name = base_name
+                self.logger.info(
+                    f"{self.log_prefix}: Creating private app "
+                    f"'[{sibling_name}]' with {len(chunk)} host(s) on the "
+                    "Netskope Tenant."
+                )
+            else:
+                sibling_name = f"{base_name} {next_number}"
+                next_number += 1
+                self.logger.info(
+                    f"{self.log_prefix}: Creating new private app "
+                    f"'[{sibling_name}]' to accommodate {len(chunk)} excess "
+                    "host(s) that exceed the capacity of the existing "
+                    f"private app(s) for '[{base_name}]'."
+                )
+            try:
+                created_app_id, created_app_name = self._create_private_app(
+                    sibling_name,
+                    default_url,
+                    publishers_list,
+                    use_publisher_dns,
+                    protocols_list,
+                )
+            except PrivateAppLimitReachedError as err:
+                remaining = [
+                    host for batch in chunks[index:] for host in batch
+                ]
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: Reached the tenant's maximum "
+                        "private app limit while creating roll-over "
+                        f"siblings for '[{base_name}]'. Skipping "
+                        f"{len(remaining)} host(s) that could not be "
+                        "accommodated."
+                    ),
+                    details=str(err),
+                )
+                return remaining, added_counts
+            self._patch_private_app(
+                tenant_name,
+                created_app_id,
+                self.netskope_helper._private_app_body(
+                    chunk,
+                    host_to_tags,
+                    publishers_list,
+                    use_publisher_dns,
+                    protocols_list,
+                ),
+                created_app_name,
+            )
+            added_counts[created_app_name] = (
+                added_counts.get(created_app_name, 0) + len(chunk)
+            )
+        return [], added_counts
+
+    def _append_private_app_hosts(
+        self,
+        unique_hosts,
+        tenant_name,
+        base_name,
+        private_app_name,
+        members,
+        host_to_tags,
+        publishers_list,
+        use_publisher_dns,
+        protocols_list,
+        default_url,
+        skip_excess_hosts,
+    ):
+        """Union new hosts into a logical private app, rolling over by 500.
+
+        New hosts (those not already present in any group member) fill the
+        existing siblings' remaining room in order; the rest roll over into
+        new sibling apps (unless ``skip_excess_hosts`` skips them, or the
+        tenant's private app limit is reached). Existing hosts are never
+        moved or removed. When filling an existing app the new batch's tags
+        are unioned with that app's current tags (so prior tags are kept).
+        """
+        existing_set = set()
+        for member in members:
+            existing_set.update(member["hosts"])
+        new_to_add = [
+            host for host in unique_hosts if host not in existing_set
+        ]
+        if not new_to_add:
+            # Nothing new to add. Refresh every group member's metadata
+            # (publishers, protocols); keep each app's existing tags via
+            # base_tags (no new hosts means no new batch tags to add). Skip
+            # the API call entirely for members whose metadata already
+            # matches the action params - it would be a no-op PATCH.
+            if members:
+                self.logger.info(
+                    f"{self.log_prefix}: All {len(unique_hosts)} provided "
+                    f"host(s) are already present in private app "
+                    f"'{private_app_name}'; no new hosts to add. Refreshing "
+                    "its publishers, protocols, tags, and use-publisher-DNS "
+                    "values."
+                )
+                for member in members:
+                    # Every host here is already in the app (that's why
+                    # there's nothing new to add), but the records can still
+                    # carry tags - and a tag may be new even when the host
+                    # isn't. So the tag set this app would end up with is its
+                    # existing tags plus any the records attached to its
+                    # hosts; comparing that to its current tags tells us
+                    # whether the update is needed.
+                    target_tag_names = set(member["tags"])
+                    for host in member["hosts"]:
+                        target_tag_names |= host_to_tags.get(host, set())
+                    if not self.netskope_helper._private_app_metadata_changed(
+                        member,
+                        publishers_list,
+                        use_publisher_dns,
+                        protocols_list,
+                        target_tag_names,
+                    ):
+                        self.logger.debug(
+                            f"{self.log_prefix}: No metadata changes for "
+                            f"private app '{member['name']}'; skipping the "
+                            "update API call."
+                        )
+                        continue
+                    self._patch_private_app(
+                        tenant_name,
+                        member["id"],
+                        self.netskope_helper._private_app_body(
+                            member["hosts"],
+                            host_to_tags,
+                            publishers_list,
+                            use_publisher_dns,
+                            protocols_list,
+                            base_tags=member["tags"],
+                        ),
+                        member["name"],
+                    )
+            else:
+                self.logger.error(
+                    message=(
+                        f"{self.log_prefix}: No private app with the name "
+                        f"'{private_app_name}' was found on the Netskope "
+                        "Tenant; skipping the action execution."
+                    ),
+                    resolution=(
+                        "Verify the private app still exists on the "
+                        "Netskope Tenant, or provide at least one valid "
+                        "host so a new private app can be created."
+                    ),
+                )
+            # Nothing was capacity-skipped or added on this path. When the
+            # app does not exist, every record here contributed only
+            # invalid/empty hosts (a valid host would have created the app),
+            # so they are already attributed as failed via the invalid-host
+            # set in _push_private_app.
+            return [], {}
+        # Some of the provided hosts are already in the group and are not
+        # re-added; report how many so it is clear what happened to them.
+        already_present = len(unique_hosts) - len(new_to_add)
+        if already_present:
+            self.logger.info(
+                f"{self.log_prefix}: {already_present} of the "
+                f"{len(unique_hosts)} provided host(s) were not added to "
+                f"private app '{private_app_name}' as they are already "
+                "present in it."
+            )
+        # When Skip Excess Hosts is enabled no new sibling apps are
+        # created, so the only capacity is the room left in the existing
+        # group members. If they are already full there is nowhere to put
+        # any new host - report skipping all of them directly instead of
+        # going through the roll-over path and reporting a "0 appended"
+        # success below.
+        if skip_excess_hosts and members:
+            available_room = sum(
+                max(0, MAX_HOSTS_PER_PRIVATE_APP - len(member["hosts"]))
+                for member in members
+            )
+            if available_room <= 0:
+                self.logger.info(
+                    f"{self.log_prefix}: Private app '{private_app_name}' "
+                    f"is already at its maximum capacity of "
+                    f"{MAX_HOSTS_PER_PRIVATE_APP} host(s) per app and "
+                    "'Skip Excess Hosts' is enabled; hence skipping all "
+                    f"{len(unique_hosts)} unique host(s)."
+                )
+                return new_to_add, {}
+        # Track how many new hosts were added to each private app.
+        added_counts = {}
+        # The Default Host is only a placeholder (seeded at creation, or left
+        # behind by a revert that reset an emptied app); once real hosts are
+        # added to an app it is dropped so it does not linger alongside them.
+        default_host = (default_url or "").strip()
+        # Fill the existing siblings' remaining room first.
+        pointer = 0
+        for member in members:
+            if pointer >= len(new_to_add):
+                break
+            current_hosts = list(member["hosts"])
+            if default_host:
+                current_hosts = [
+                    host for host in current_hosts if host != default_host
+                ]
+            room = MAX_HOSTS_PER_PRIVATE_APP - len(current_hosts)
+            if room <= 0:
+                self.logger.info(
+                    f"{self.log_prefix}: Private app '{member['name']}' is "
+                    f"already full ({MAX_HOSTS_PER_PRIVATE_APP} host(s)); "
+                    "adding the remaining host(s) to the next app."
+                )
+                continue
+            take = new_to_add[pointer: pointer + room]
+            # Union this batch's tags with the existing app's tags so the
+            # filled app keeps its prior tags and gains the new ones. The
+            # Default Host placeholder (if any) is dropped from current_hosts
+            # above since at least one real host is being added here.
+            self._patch_private_app(
+                tenant_name,
+                member["id"],
+                self.netskope_helper._private_app_body(
+                    current_hosts + take,
+                    host_to_tags,
+                    publishers_list,
+                    use_publisher_dns,
+                    protocols_list,
+                    base_tags=member["tags"],
+                ),
+                member["name"],
+            )
+            added_counts[member["name"]] = len(take)
+            pointer += len(take)
+        # Any remaining new hosts roll over into new sibling apps.
+        skipped, overflow_counts = self._create_overflow_siblings(
+            tenant_name,
+            base_name,
+            members,
+            new_to_add[pointer:],
+            skip_excess_hosts,
+            default_url,
+            host_to_tags,
+            publishers_list,
+            use_publisher_dns,
+            protocols_list,
+        )
+        added_counts.update(overflow_counts)
+        placed = len(new_to_add) - len(skipped)
+        skip_note = (
+            f" {len(skipped)} excess host(s) were skipped."
+            if skipped
+            else ""
+        )
+        self.logger.info(
+            f"{self.log_prefix}: Successfully appended {placed} new "
+            f"host(s) to private app '{private_app_name}'.{skip_note}"
+        )
+        # The capacity-skipped hosts (Skip Excess / tenant limit) are
+        # returned so the caller can attribute failed action ids, along
+        # with the per-app added-host counts for the final summary.
+        return skipped, added_counts
+
+    def _compact_private_app_group(
+        self,
+        tenant_name,
+        base_name,
+        private_app_name,
+        host_to_tags,
+        publishers_list,
+        use_publisher_dns,
+        protocols_list,
+        default_url,
+    ):
+        """Consolidate a private app group after an append (bulk sync only).
+
+        A revert removes hosts in place, which can leave a group with
+        partially filled apps (for example ``[X]``=500, ``[X 2]``=260,
+        ``[X 3]``=200) or with the base app reset to the Default Host
+        placeholder while a sibling still holds real hosts. This re-packs the
+        group's real hosts into the fewest apps (``MAX_HOSTS_PER_PRIVATE_APP``
+        each), **filling the existing slots in order from the base first** and
+        deleting the trailing slots left unused. No real host is dropped -
+        only redistributed - and the group is only ever shrunk, so this never
+        creates a new app. Compaction runs only when it would free a slot (a
+        surplus or a placeholder slot), to avoid needless churn.
+
+        The base (and any lower-numbered slot still needed to hold the
+        re-packed hosts) is **reused** even when it currently holds only the
+        Default Host placeholder - the real hosts overwrite the placeholder.
+        Only the **trailing surplus** slots are removed: a slot that held real
+        hosts (now moved up) is reset to the Default Host if its delete is
+        rejected (so it keeps no stale duplicates), while a trailing slot
+        holding only the placeholder is just deleted (on a delete failure it
+        is left as-is). The Default Host placeholder value is never merged into
+        another app. A lone group app is left untouched.
+
+        It is a best-effort cleanup: any error is logged but never raised,
+        so a compaction failure does not fail the action.
+
+        Tags and metadata follow the hosts: each rewritten slot is given the
+        publishers / protocols / use-publisher-DNS from the current action,
+        and its tags are the union of the tags of the source app(s) of the
+        hosts that land in it (so a moved host's tags are carried into its new
+        app) plus the current sync's tags (``host_to_tags``).
+
+        Args:
+            tenant_name (str): Tenant base URL.
+            base_name (str): Logical app name without brackets.
+            private_app_name (str): The base app name ``[base]`` (for logs).
+            host_to_tags (dict[str, set[str]]): host -> contributing tag
+                names from the current sync.
+            publishers_list (list[dict]): Resolved publisher entries.
+            use_publisher_dns (bool): Whether to use the publisher DNS.
+            protocols_list (list[dict]): Protocol entries for the apps.
+            default_url (str): Default Host placeholder.
+        """
+        try:
+            # Re-fetch the group fresh - the append just mutated it.
+            existing_private_apps = self._get_private_apps(
+                get_hosts_of=private_app_name
+            )
+            members = self.netskope_helper._ordered_private_app_group(
+                existing_private_apps, base_name
+            )
+            if len(members) <= 1:
+                # A single app (or none) cannot be consolidated, and a lone
+                # placeholder app is left as the group's anchor.
+                return
+            default_host = (default_url or "").strip()
+            # Collect every real host across the group in member order
+            # (base-first), de-duplicated, while remembering the tags carried
+            # by each host's source app so they follow the host when it moves.
+            # The Default Host placeholder value is never collected, so it is
+            # never merged into another app.
+            all_hosts = []
+            seen = set()
+            host_to_source_tags = {}
+            for member in members:
+                for host in member["hosts"]:
+                    if not host or host == default_host:
+                        continue
+                    host_to_source_tags.setdefault(host, set()).update(
+                        member["tags"]
+                    )
+                    if host not in seen:
+                        seen.add(host)
+                        all_hosts.append(host)
+            if not all_hosts:
+                # The group holds only placeholder host(s); there is nothing
+                # real to consolidate, so the apps (and the anchor) are left
+                # as-is.
+                return
+            target_count = (
+                len(all_hosts) + MAX_HOSTS_PER_PRIVATE_APP - 1
+            ) // MAX_HOSTS_PER_PRIVATE_APP
+            if len(members) <= target_count:
+                # The group already uses the minimum number of apps; there is
+                # no surplus or placeholder slot to reclaim, so skip to avoid
+                # churn. (A placeholder slot holds no real host, so when one
+                # exists len(members) always exceeds target_count.)
+                return
+            chunks = [
+                all_hosts[index: index + MAX_HOSTS_PER_PRIVATE_APP]
+                for index in range(
+                    0, len(all_hosts), MAX_HOSTS_PER_PRIVATE_APP
+                )
+            ]
+            self.logger.info(
+                f"{self.log_prefix}: Compacting private app group "
+                f"'{private_app_name}' from {len(members)} app(s) to "
+                f"{len(chunks)} app(s)."
+            )
+            # Re-pack the hosts into the existing app slots in order, filling
+            # the base (and lower-numbered siblings) first - reusing a slot
+            # even when it currently holds only the Default Host placeholder.
+            # Each rewritten slot carries the tags of the source app(s) of the
+            # hosts that land in it (base_tags) plus the current sync's tags
+            # (host_to_tags), so tags follow the hosts as they move.
+            for index, chunk in enumerate(chunks):
+                member = members[index]
+                if chunk == member["hosts"]:
+                    # Slot already holds exactly these hosts (so the same
+                    # source tags); skip the redundant PATCH.
+                    continue
+                chunk_source_tags = set()
+                for host in chunk:
+                    chunk_source_tags |= host_to_source_tags.get(host, set())
+                self._patch_private_app(
+                    tenant_name,
+                    member["id"],
+                    self.netskope_helper._private_app_body(
+                        chunk,
+                        host_to_tags,
+                        publishers_list,
+                        use_publisher_dns,
+                        protocols_list,
+                        base_tags=chunk_source_tags,
+                    ),
+                    member["name"],
+                )
+            # Remove the trailing surplus slots left unused after the re-pack.
+            # A slot that held real hosts (now moved up) is reset to the
+            # Default Host if its delete is rejected, so it keeps no stale
+            # duplicate hosts; a slot holding only the placeholder is just
+            # deleted (on a delete failure it is left as-is).
+            for member in members[len(chunks):]:
+                if default_host and member["hosts"] == [default_host]:
+                    self._delete_private_app(
+                        tenant_name, member["id"], member["name"]
+                    )
+                else:
+                    self._remove_surplus_private_app(
+                        tenant_name,
+                        member,
+                        publishers_list,
+                        use_publisher_dns,
+                        protocols_list,
+                        default_url,
+                    )
+        except Exception as err:
+            self.logger.error(
+                message=(
+                    f"{self.log_prefix}: Error occurred while consolidating "
+                    f"private app group '{private_app_name}'. The hosts were "
+                    "added successfully; only the cleanup of partially "
+                    f"filled apps was skipped. Error: {err}"
+                ),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
+            )
 
     def _tag_application(
         self,
@@ -3347,7 +8334,7 @@ class NetskopePlugin(PluginBase):
                 )
             try:
                 self.logger.debug(
-                    f"{self.log_prefix}: {log_message.capitalize()}."
+                    f"{self.log_prefix}: {_capitalize_first(log_message)}."
                 )
                 data = (
                     {"tag": tag}
@@ -3552,27 +8539,27 @@ class NetskopePlugin(PluginBase):
                 self.tenant.parameters.get("v2token", "")
             )
         }
-        
+
         tag_cache = {}
         offset = 0
         total_fetched = 0
-        
+
         try:
             self.logger.info(
                 f"{self.log_prefix}: Fetching all tags from Netskope."
             )
-            
+
             while True:
                 log_message = f"fetching tags (offset: {offset}, limit: {TAG_CACHE_PAGE_SIZE})"
                 self.logger.debug(f"{self.log_prefix}: {log_message.capitalize()}.")
-                
+
                 url = f"{tenant_name}{URLS.get('V2_DEVICE_GET_TAGS')}"
                 payload = {
                     "devices": [],
                     "offset": offset,
                     "limit": TAG_CACHE_PAGE_SIZE
                 }
-                
+
                 response = self.netskope_helper._api_call_helper(
                     url=url,
                     method="post",
@@ -3583,7 +8570,7 @@ class NetskopePlugin(PluginBase):
                     message=f"Error occurred while {log_message}",
                     logger_msg=log_message,
                 )
-                
+
                 if not response.get("success"):
                     err_msg = (
                         "Error occurred while fetching all tags "
@@ -3596,10 +8583,10 @@ class NetskopePlugin(PluginBase):
                         details=str(response.get("error", {}))
                     )
                     raise NetskopeException(err_msg)
-                
+
                 data = response.get("data", {})
                 tags = data.get("data", []) if data and isinstance(data, dict) else []
-                
+
                 for tag_info in tags:
                     if isinstance(tag_info, dict):
                         # as the Netskope API is case insensitive ,
@@ -3608,26 +8595,26 @@ class NetskopePlugin(PluginBase):
                         tag_id = tag_info.get("id")
                         if tag_name and tag_id:
                             tag_cache[tag_name] = tag_id
-                
+
                 total_fetched += len(tags)
-                
+
                 total_count = data.get("total_count", 0)
                 self.logger.debug(
                     f"{self.log_prefix}: Fetched {len(tags)} tag(s) in current page. "
                     f"Total fetched: {total_fetched}/{total_count}."
                 )
-                
+
                 if total_fetched >= total_count or len(tags) < TAG_CACHE_PAGE_SIZE:
                     break
-                
+
                 offset += TAG_CACHE_PAGE_SIZE
-            
+
             self.logger.info(
                 f"{self.log_prefix}: Successfully fetched {len(tag_cache)} tag(s)"
                 " from Netskope tenant"
             )
             return tag_cache
-            
+
         except Exception as e:
             err_msg = (
                 "An Unexpected error occurred while "
@@ -3706,7 +8693,9 @@ class NetskopePlugin(PluginBase):
                 )
             elif action in ["append", "replace"]:
                 log_message = f"creating tag '{tag}'"
-                self.logger.debug(f"{self.log_prefix}: {log_message.capitalize()}.")
+                self.logger.debug(
+                    f"{self.log_prefix}: {_capitalize_first(log_message)}."
+                )
 
                 try:
                     url = f"{tenant_name}{URLS.get('V2_DEVICE_TAG')}"
@@ -3840,7 +8829,7 @@ class NetskopePlugin(PluginBase):
         else:  # remove
             log_message = "removing tags from devices"
             url = f"{tenant_name}{URLS.get('V2_DEVICE_BULK_REMOVE_TAGS')}"
-        
+
         data = {"tags": tag_ids, "devices": devices}
 
         self.logger.debug(f"{self.log_prefix}: {log_message.capitalize()}.")
@@ -4597,73 +9586,285 @@ class NetskopePlugin(PluginBase):
         return tags, device_id, device_user_key, hostname, tag_action
 
     def revert_action(self, action: Action):
-        """Revert the action.
+        """Revert an action for a single excluded record.
+
+        The framework calls this once per record that no longer matches the
+        business rule. For the 'Add host to Private App' action this removes
+        that record's host(s) from the private app group in place: the
+        host(s) are dropped from whichever group member(s) contain them, and
+        the record's tags are stripped from those member(s) too.
+
+        Removal is in place - hosts are never moved between apps here (the
+        bulk sync's compaction pass reclaims any apps a revert leaves
+        partially filled). A member left with no hosts is deleted when it is
+        a roll-over sibling, or reset to the Default Host when it is the base
+        app (a private app must keep at least one host); when no Default Host
+        is configured the emptied base app is deleted instead.
 
         Args:
-            action (Action): Action to be reverted.
+            action (Action): Action to be reverted (carries the record's
+                resolved parameters).
+
+        Raises:
+            NotImplementedError: For action types that do not support a
+                per-record revert.
+            NetskopeException: On an unrecoverable error while removing the
+                host(s).
         """
         helper = AlertsHelper()
         self.tenant = helper.get_tenant_crev2(self.name)
+        # Mirror execute_action: keep the multi-value fields intact so the
+        # full set of the record's hosts (and its tags) is available rather
+        # than collapsed to a single latest value.
         action.parameters = get_latest_values(
-            action.parameters, exclude_keys=["tags", "protocol", "publishers"]
+            action.parameters,
+            exclude_keys=["host", "tags", "protocol", "publishers"],
         )
-        if action.value == "private_app":
-            action_dict = action.parameters
-            existing_private_app_name = action_dict.get("private_app_name", "")
-            new_private_app_name = action_dict.get("name", "")
-            host = action_dict.get("host", "")
-            if existing_private_app_name == "create":
-                private_app_name = f"[{new_private_app_name}]"
-            else:
-                private_app_name = existing_private_app_name
-            if not host:
+        if action.value != "private_app":
+            raise NotImplementedError(
+                f"Revert action is not supported for '{action.value}' "
+                "action in Netskope Risk Exchange plugin."
+            )
+        tenant_name = self.tenant.parameters.get("tenantName", "").strip()
+        existing_private_app_name = action.parameters.get(
+            "private_app_name", ""
+        )
+        new_private_app_name = action.parameters.get("name", "")
+        if existing_private_app_name == "create":
+            base_name = new_private_app_name
+        else:
+            base_name = existing_private_app_name.removeprefix(
+                "["
+            ).removesuffix("]")
+        private_app_name = f"[{base_name}]"
+        try:
+            # Normalise the record's host(s) to remove - a Source field (a
+            # list) or a Static field (a comma-separated string) - via the
+            # shared _normalize_csv_values helper (trims, drops empties,
+            # de-duplicates), as execute_actions and the profile actions do.
+            hosts_to_remove = set(
+                self.netskope_helper._normalize_csv_values(
+                    action.parameters.get("host")
+                )
+            )
+            if not hosts_to_remove:
                 self.logger.info(
-                    f"{self.log_prefix}: Host value not found in the "
-                    f"record for private app {private_app_name}. "
-                    "Hence, skipped execution of revert action."
+                    f"{self.log_prefix}: No host found in the record for "
+                    f"private app '{private_app_name}'; hence skipping the "
+                    "revert action."
+                )
+                return
+            # Short-circuit: a host that fails the same validation used by the
+            # add-host action could never have been added to the app, so
+            # fetching the app to remove it would be a wasted API call. Keep
+            # only the valid hosts; if none are valid, skip before the
+            # fetch-apps call below.
+            valid_hosts, _, _ = (
+                self.netskope_helper.validate_hosts_for_private_app(
+                    hosts_to_push=list(hosts_to_remove),
+                    private_app_name=private_app_name,
+                )
+            )
+            if not valid_hosts:
+                self.logger.info(
+                    f"{self.log_prefix}: No valid host found in the reverted "
+                    f"record for private app '{private_app_name}'; hence "
+                    "skipping the revert action for this record."
+                )
+                return
+            hosts_to_remove = set(valid_hosts)
+            # Resolve the record's tags so they can be stripped from the
+            # member(s) the host(s) are removed from.
+            raw_tags = action.parameters.get("tags") or []
+            if isinstance(raw_tags, str):
+                raw_tags = [
+                    tag.strip()
+                    for tag in raw_tags.split(",")
+                    if tag.strip()
+                ]
+            record_valid_tags, _, _ = (
+                self.netskope_helper.validate_tags_for_private_app(
+                    raw_tags, private_app_name
+                )
+            )
+            record_tag_names = {
+                tag["tag_name"] for tag in record_valid_tags
+            }
+            self.logger.info(
+                f"{self.log_prefix}: Attempting to remove "
+                f"{len(hosts_to_remove)} host(s) of the reverted record from "
+                f"private app '{private_app_name}'."
+            )
+            existing_private_apps = self._get_private_apps(
+                get_hosts_of=private_app_name
+            )
+            members = self.netskope_helper._ordered_private_app_group(
+                existing_private_apps, base_name
+            )
+            if not members:
+                self.logger.info(
+                    f"{self.log_prefix}: No private app with the name "
+                    f"'{private_app_name}' was found on the Netskope Tenant; "
+                    "hence skipping the revert action."
+                )
+                return
+            # Resolve the metadata once so the host-removal PATCH keeps the
+            # app's ports/publishers/DNS aligned (and does not wipe them).
+            tcp_port = action.parameters.get("tcp_ports", "") or ""
+            udp_port = action.parameters.get("udp_ports", "") or ""
+            protocols_list = (
+                self.netskope_helper._build_private_app_protocols(
+                    action.parameters.get("protocol", []),
+                    [p.strip() for p in tcp_port.split(",") if p.strip()],
+                    [p.strip() for p in udp_port.split(",") if p.strip()],
+                )
+            )
+            publishers_list = self._resolve_private_app_publishers(
+                action.parameters.get("publishers", []), private_app_name
+            )
+            use_publisher_dns = action.parameters.get(
+                "use_publisher_dns", False
+            )
+            default_url = action.parameters.get("default_url", "").strip()
+            removed_hosts = set()
+            for member in members:
+                remaining = [
+                    host
+                    for host in member["hosts"]
+                    if host not in hosts_to_remove
+                ]
+                if len(remaining) == len(member["hosts"]):
+                    # This member held none of the reverted host(s).
+                    continue
+                removed_hosts.update(
+                    host
+                    for host in member["hosts"]
+                    if host in hosts_to_remove
+                )
+                # Strip the reverted record's tags from this member (a tag
+                # also contributed by a still-active record may be removed -
+                # documented known behavior).
+                new_tag_names = [
+                    tag
+                    for tag in member["tags"]
+                    if tag not in record_tag_names
+                ]
+                if remaining:
+                    data = {
+                        "host": ",".join(remaining),
+                        "tags": [
+                            {"tag_name": name}
+                            for name in sorted(new_tag_names)
+                        ],
+                        "publishers": publishers_list,
+                        "use_publisher_dns": use_publisher_dns,
+                    }
+                    if protocols_list:
+                        data["protocols"] = protocols_list
+                    self._patch_private_app(
+                        tenant_name, member["id"], data, member["name"]
+                    )
+                elif member["number"] != 1:
+                    # Emptied roll-over sibling: delete it (reset to the
+                    # Default Host if the delete is rejected).
+                    self._remove_surplus_private_app(
+                        tenant_name,
+                        member,
+                        publishers_list,
+                        use_publisher_dns,
+                        protocols_list,
+                        default_url,
+                    )
+                elif default_url:
+                    # Emptied base app: a private app must keep at least one
+                    # host, so reset it to the Default Host placeholder.
+                    self.logger.info(
+                        f"{self.log_prefix}: Removing the last host(s) from "
+                        f"the base private app '{member['name']}'; resetting "
+                        f"it to the Default Host '{default_url}'."
+                    )
+                    reset_body = {
+                        "host": default_url,
+                        "tags": [
+                            {"tag_name": name}
+                            for name in sorted(new_tag_names)
+                        ],
+                        "publishers": publishers_list,
+                        "use_publisher_dns": use_publisher_dns,
+                    }
+                    if protocols_list:
+                        reset_body["protocols"] = protocols_list
+                    self._patch_private_app(
+                        tenant_name,
+                        member["id"],
+                        reset_body,
+                        member["name"],
+                    )
+                else:
+                    # Base app emptied and no Default Host configured - it
+                    # cannot be reset to an empty host list, so delete it.
+                    self.logger.info(
+                        f"{self.log_prefix}: Removing the last host(s) from "
+                        f"the base private app '{member['name']}' with no "
+                        "Default Host configured; hence deleting the app."
+                    )
+                    self._delete_private_app(
+                        tenant_name, member["id"], member["name"]
+                    )
+            if not removed_hosts:
+                self.logger.info(
+                    f"{self.log_prefix}: None of the reverted record's "
+                    f"host(s) were found in private app '{private_app_name}'; "
+                    "hence nothing was removed."
                 )
                 return
             self.logger.info(
-                f"{self.log_prefix}: Attempting to remove the host {host} "
-                f"from private app {private_app_name}."
+                f"{self.log_prefix}: Successfully removed "
+                f"{len(removed_hosts)} host(s) of the reverted record from "
+                f"private app '{private_app_name}'."
             )
-            app = self._get_private_app(
-                prefix=private_app_name, has_host=action_dict.get("host", "")
+        except NetskopeException:
+            raise
+        except Exception as err:
+            error_message = (
+                "Error occurred while removing the reverted record's "
+                f"host(s) from private app '{private_app_name}'."
             )
-            if not app:
-                self.logger.info(
-                    f"{self.log_prefix}: Host {host} not found "
-                    f"in {private_app_name}. "
-                    "Hence, skipped execution of revert action."
-                )
-                return
-            data = {
-                "host": ",".join(
-                    list(filter(
-                        lambda x: x != host, app.get("host", "").split(",")
-                    ))
-                )
-            }
-            return self._patch_private_app(
-                self.tenant.parameters.get('tenantName').strip(),
-                app.get("app_id", ""),
-                data,
+            self.logger.error(
+                message=f"{self.log_prefix}: {error_message} Error: {err}",
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
             )
-        raise NotImplementedError()
+            raise NetskopeException(error_message)
 
-    def _patch_private_app(self, tenant: str, app_id: str, data: dict):
+    def _patch_private_app(
+        self, tenant: str, app_id: str, data: dict, app_name: str = ""
+    ):
         """Patch an existing private app.
 
         Args:
             tenant (str): Tenant base URL.
             app_id (str): Existing app id.
             data (dict): Request body.
+            app_name (str, optional): Name of the private app being \
+                patched, included in log messages for context. Defaults \
+                to "".
 
         Raises:
             NetskopeException: Error in the response.
             NetskopeException: Non-2xx status code.
         """
-        logger_msg = "adding host to private app"
+        logger_msg = (
+            f"adding host to private app '{app_name}'"
+            if app_name
+            else "adding host to private app"
+        )
+        self.logger.debug(
+            f"{self.log_prefix}: {_capitalize_first(logger_msg)}."
+        )
         url = (
             f"{tenant}{URLS.get('V2_PRIVATE_APP_PATCH').format(app_id)}"
         )
@@ -4720,8 +9921,8 @@ class NetskopePlugin(PluginBase):
                 )
 
             self.logger.info(
-                f"{self.log_prefix}: Successfully updated the private app for "
-                f"configuration {self.plugin_name}."
+                f"{self.log_prefix}: Successfully updated the private app"
+                f" {app_name}."
             )
         except NetskopeException:
             raise
@@ -4732,16 +9933,36 @@ class NetskopePlugin(PluginBase):
                     f"{self.log_prefix}: {error_message} "
                     f"Error: {err}"
                 ),
-                details=str(traceback.format_exc()),
+                details=re.sub(
+                    r"token=([0-9a-zA-Z]*)",
+                    "token=********&",
+                    traceback.format_exc(),
+                ),
             )
             raise NetskopeException(error_message)
         return
 
-    def _execute_private_app_action(self, action_dict: dict):
+    def _execute_private_app_action(
+        self,
+        action_dict: dict,
+        host_to_tags: Optional[dict] = None,
+        compact: bool = False,
+    ):
         """Execute action on the given parameters.
 
         Args:
             action_dict (dict): Action parameters.
+            host_to_tags (Optional[dict]): Pre-built ``{host -> set(tag
+                name)}`` map for per-batch tag scoping (bulk path). When
+                None, tags are taken uniformly from ``action_dict``.
+            compact (bool): When True (bulk sync), consolidate the app group
+                after the append to reclaim apps left partially filled by
+                earlier reverts. Defaults to False.
+
+        Returns:
+            tuple[set[str], dict[str, int]]: ``(not_placed, added_counts)``
+                forwarded from ``_push_private_app`` - the not-placed host
+                set and the per-app added-host counts.
         """
         protocols = action_dict.get("protocol", [])
         tcp_port = action_dict.get("tcp_ports", "") or ""
@@ -4768,23 +9989,11 @@ class NetskopePlugin(PluginBase):
             raise NetskopeException(err_msg)
         tags = action_dict.get("tags", [])
         if tags and isinstance(tags, str):
-            tags = list(map(lambda x: x.strip(), tags.split(",")))
-            for tag in tags:
-                if len(tag) > 30:
-                    err_msg = (
-                        "Found tag length greater than 30 characters. "
-                        "Tag length should be less than or "
-                        "equal to 30 characters."
-                    )
-                    self.logger.error(
-                        message=err_msg,
-                        details=str(tag),
-                        resolution=(
-                            "Make sure tag length is less than or "
-                            "equal to 30 characters."
-                        )
-                    )
-                    raise NetskopeException(err_msg)
+            tags = [tag.strip() for tag in tags.split(",")]
+        # Tag length/format validation happens inside _push_private_app via
+        # validate_tags_for_private_app: invalid tags (empty or exceeding the
+        # maximum length) are skipped and the remaining valid tags are still
+        # pushed. Static tags are already validated at save time.
 
         return self._push_private_app(
             action_dict.get("host", ""),
@@ -4797,6 +10006,9 @@ class NetskopePlugin(PluginBase):
             use_publisher_dns=use_publisher_dns,
             default_url=action_dict.get("default_url", "").strip(),
             tags=tags,
+            skip_excess_hosts=action_dict.get("skip_excess_hosts", False),
+            host_to_tags=host_to_tags,
+            compact=compact,
         )
 
     def revert_uci_update_impact(self, anomaly_id: str):
@@ -4958,7 +10170,7 @@ class NetskopePlugin(PluginBase):
                         start_idx = batch_num * TAG_DEVICE_BATCH_SIZE
                         end_idx = min(start_idx + TAG_DEVICE_BATCH_SIZE, len(unique_devices))   # noqa
                         device_batch = unique_devices[start_idx:end_idx]
-                        
+
                         batch_action_ids = []
                         batch_device_keys = set(
                             (d.get("nsdeviceuid"), d.get("userkey"))  # noqa
@@ -4973,7 +10185,7 @@ class NetskopePlugin(PluginBase):
                                 if action_device_key in batch_device_keys:
                                     batch_action_ids.append(action_id)
                                     break
-                        
+
                         try:
                             self.logger.info(
                                 f"{self.log_prefix}: Processing batch {batch_num + 1}/{total_batches} "     # noqa
@@ -5230,9 +10442,17 @@ class NetskopePlugin(PluginBase):
         """
         helper = AlertsHelper()
         self.tenant = helper.get_tenant_crev2(self.name)
+        # The 'Add host to Private App' action consumes the full set of
+        # values from its Source/Static fields, so its multi-value
+        # parameters must NOT be collapsed to a single latest value here.
         action.parameters = get_latest_values(
             action.parameters,
-            exclude_keys=["host", "tags", "protocol", "publishers"],
+            exclude_keys=[
+                "host",
+                "tags",
+                "protocol",
+                "publishers",
+            ],
         )
         self.logger.info(
             f"{self.log_prefix}: Executing '{action.label}' "
@@ -5405,6 +10625,11 @@ class NetskopePlugin(PluginBase):
                 f"{self.log_prefix}: Created/updated app instance "
                 f"{instance_name} successfully."
             )
+        # The Add to Destination/DNS/Service Profile and Create Device
+        # Classification actions are handled exclusively through
+        # ``execute_actions`` (bulk). The plugin requires CE 6.1.0+, where
+        # bulk execution is always used, so no single-record branch is
+        # implemented for them here.
 
     def execute_actions(self, actions, revert: bool = False):
         """Execute actions in bulk.
@@ -5432,50 +10657,128 @@ class NetskopePlugin(PluginBase):
             )
         failed_action_ids = []
         if first_action.value == "private_app":
+            # Group records by target app name, keeping (action_id, params)
+            # so each host can be mapped back to the contributing records.
             private_apps = {}
-            action_id_to_app_mapping = {}
             for action_dict in actions:
                 id, action = action_dict.get("id"), action_dict.get("params")
+                selected = action.parameters.get("private_app_name", "")
                 app_name = (
-                    action.parameters.get("private_app_name", "")
-                    if action.parameters.get("private_app_name", "") != "create"
+                    selected
+                    if selected != "create"
                     else action.parameters.get("name", "")
                 )
-                private_apps.setdefault(app_name, []).append(action.parameters)
-                action_id_to_app_mapping[id] = app_name
+                private_apps.setdefault(app_name, []).append(
+                    (id, action.parameters)
+                )
+            # Tracks how many hosts were added to each private app across
+            # all groups; surfaced in the final summary log's details.
+            hosts_per_app = {}
             for app_name, batched_actions in private_apps.items():
-                batch_action_ids = [
-                    action_id for action_id, mapped_app_name in action_id_to_app_mapping.items()
-                    if mapped_app_name == app_name
-                ]
+                batch_action_ids = [aid for aid, _ in batched_actions]
                 try:
-                    first_action = batched_actions[0]
-                    params = first_action.copy()
-                    params["host"] = [
-                        host_item
-                        for action in batched_actions
-                        for host_item in (
-                            action["host"] if isinstance(action["host"], list)
-                            else [action["host"]]
+                    params = batched_actions[0][1].copy()
+                    # One pass over the group's records builds: the unioned
+                    # host list; the per-batch tag map (host -> contributing
+                    # tag names) for tag scoping; and the per-record host
+                    # sets for failed-action-id attribution.
+                    union_hosts = []
+                    host_to_tags = {}
+                    record_to_hosts = {}
+                    for aid, record_params in batched_actions:
+                        # Use ``or []`` (not just a get default) so a tags
+                        # value of None - not only a missing key - is
+                        # normalised to an empty list before iterating.
+                        raw_tags = record_params.get("tags") or []
+                        if isinstance(raw_tags, str):
+                            raw_tags = [
+                                tag.strip()
+                                for tag in raw_tags.split(",")
+                                if tag.strip()
+                            ]
+                        record_valid_tags, _, _ = (
+                            self.netskope_helper.validate_tags_for_private_app(
+                                raw_tags, app_name
+                            )
                         )
-                        if host_item
-                    ]
+                        record_tag_names = {
+                            tag["tag_name"] for tag in record_valid_tags
+                        }
+                        # Host accepts a Source field (a list) or a Static
+                        # field (a comma-separated string); the shared
+                        # _normalize_csv_values helper handles both - trimming,
+                        # dropping empties, and de-duplicating - so each host
+                        # is processed individually (as the profile actions).
+                        record_hosts = (
+                            self.netskope_helper._normalize_csv_values(
+                                record_params.get("host")
+                            )
+                        )
+                        host_set = set()
+                        for host_value in record_hosts:
+                            union_hosts.append(host_value)
+                            host_set.add(host_value)
+                            host_to_tags.setdefault(
+                                host_value, set()
+                            ).update(record_tag_names)
+                        record_to_hosts[aid] = host_set
+                    params["host"] = union_hosts
                     params = get_latest_values(
                         params,
                         exclude_keys=["host", "tags", "protocol", "publishers"],
                     )
-                    self._execute_private_app_action(params)
+                    # compact=True: after appending this group's hosts,
+                    # consolidate the app group so apps left partially filled
+                    # by earlier reverts are re-packed once per sync.
+                    not_placed, added_counts = (
+                        self._execute_private_app_action(
+                            params, host_to_tags, compact=True
+                        )
+                    )
+                    not_placed = not_placed or set()
+                    # Accumulate the per-app added-host counts for the final
+                    # summary log.
+                    for name, count in (added_counts or {}).items():
+                        hosts_per_app[name] = (
+                            hosts_per_app.get(name, 0) + count
+                        )
+                    # A record fails only when EVERY host it contributed was
+                    # not placed (invalid or capacity-skipped). A 0-host
+                    # record is a vacuous subset -> it fails too.
+                    for aid, host_set in record_to_hosts.items():
+                        if host_set.issubset(not_placed):
+                            failed_action_ids.append(aid)
                 except Exception as e:
                     failed_action_ids.extend(batch_action_ids)
                     self.logger.error(
-                        f"{self.log_prefix}: Error occurred while adding "
-                        f"hosts to private apps. Error: {str(e)}"
+                        message=(
+                            f"{self.log_prefix}: Error occurred while adding "
+                            f"hosts to private apps. Error: {str(e)}"
+                        ),
+                        details=re.sub(
+                            r"token=([0-9a-zA-Z]*)",
+                            "token=********&",
+                            traceback.format_exc(),
+                        ),
                     )
 
+            total_hosts_added = sum(hosts_per_app.values())
+            self.logger.info(
+                message=(
+                    f"{self.log_prefix}: Completed the '{action_label}' "
+                    f"action: added {total_hosts_added} host(s) across "
+                    f"{len(hosts_per_app)} private app(s). Expand log to"
+                    " view hosts added per Private App."
+                ),
+                details=(
+                    "Hosts added per private app: "
+                    f"{hosts_per_app}"
+                ),
+            )
             return ActionResult(
                 success=True,
                 message="Successfully added hosts to private apps.",
-                failed_action_ids=failed_action_ids
+                failed_action_ids=list(dict.fromkeys(failed_action_ids)),
             )
         elif first_action.value in ["add", "remove"]:
             skip_count = 0
@@ -5907,6 +11210,447 @@ class NetskopePlugin(PluginBase):
                 message="Successfully reset UCI score for users.",
                 failed_action_ids=failed_action_ids
             )
+        elif first_action.value == "destination_profile":
+            profile_groups = {}
+            for action_dict in actions:
+                id, action = (
+                    action_dict.get("id"),
+                    action_dict.get("params"),
+                )
+                params = action.parameters
+                selected_profile = params.get(
+                    "destination_profile_name", ""
+                )
+                # new_profile_name only matters when creating a profile; for
+                # an existing profile it is left at its (possibly per-record
+                # source) default, so excluding it from the key keeps all
+                # records targeting the same existing profile in one group.
+                group_key = (
+                    selected_profile,
+                    params.get("new_profile_name", "")
+                    if selected_profile == "create"
+                    else "",
+                )
+                group = profile_groups.setdefault(
+                    group_key,
+                    {
+                        "params": params,
+                        "values": [],
+                        "ids": [],
+                        "value_to_ids": {},
+                    },
+                )
+                group["ids"].append(id)
+                normalized = self.netskope_helper._normalize_csv_values(
+                    params.get("destination_values", "")
+                )
+                group["values"].extend(normalized)
+                # Track which action id(s) each value came from so that a
+                # value that fails or is skipped can be attributed back
+                # to the originating action(s) as a failed action id.
+                for value in normalized:
+                    group["value_to_ids"].setdefault(value, set()).add(id)
+            for group in profile_groups.values():
+                params = group["params"]
+                batch_ids = group["ids"]
+                value_to_ids = group["value_to_ids"]
+                values = self.netskope_helper._normalize_csv_values(group["values"])
+                # Optional per-action override for the tenant-wide
+                # exact-match value limit; empty/invalid falls back to
+                # the default constant inside the capacity helper.
+                raw_limit = params.get("exact_match_total_limit", "")
+                try:
+                    exact_total_limit = (
+                        int(raw_limit)
+                        if str(raw_limit).strip() != ""
+                        else None
+                    )
+                except (TypeError, ValueError):
+                    exact_total_limit = None
+                try:
+                    shared, not_applied = (
+                        self._push_destination_profile(
+                            destination_values=values,
+                            existing_profile_name=params.get(
+                                "destination_profile_name", ""
+                            ),
+                            new_profile_name=params.get(
+                                "new_profile_name", ""
+                            ),
+                            new_profile_description=params.get(
+                                "new_profile_description", ""
+                            ),
+                            match_type=params.get(
+                                "profile_match_type", ""
+                            ),
+                            apply_pending_changes=params.get(
+                                "apply_pending_changes", "No"
+                            ),
+                            operation=params.get("operation", "append"),
+                            exact_total_limit=exact_total_limit,
+                        )
+                    )
+                    self.netskope_helper._attribute_failed_ids(
+                        not_applied, value_to_ids, failed_action_ids
+                    )
+                    if params.get("operation", "append") == "replace":
+                        summary = (
+                            f"Successfully replaced the destination "
+                            f"profile's values with {shared} network "
+                            "target(s)."
+                        )
+                    else:
+                        summary = (
+                            f"Successfully added {shared} network "
+                            "target(s) to the destination profile."
+                        )
+                    self.logger.info(f"{self.log_prefix}: {summary}")
+                except Exception as e:
+                    failed_action_ids.extend(batch_ids)
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: Error occurred while "
+                            "adding network targets to the "
+                            f"destination profile. Error: {e}"
+                        ),
+                        details=re.sub(
+                            r"token=([0-9a-zA-Z]*)",
+                            "token=********&",
+                            traceback.format_exc(),
+                        ),
+                    )
+            return ActionResult(
+                success=True,
+                message=(
+                    "Successfully added network targets to "
+                    "destination profiles."
+                ),
+                failed_action_ids=list(set(failed_action_ids)),
+            )
+        elif first_action.value == "dns_profile":
+            profile_groups = {}
+            for action_dict in actions:
+                id, action = (
+                    action_dict.get("id"),
+                    action_dict.get("params"),
+                )
+                params = action.parameters
+                profile_value = params.get("dns_profile_name", "")
+                # new_profile_name only matters when creating a profile (the
+                # packed dropdown id is "create"); for an existing profile it
+                # keeps a per-record source default, so exclude it from the
+                # key to keep same-profile records in one group.
+                is_create = (
+                    profile_value.partition(CUSTOM_SEPARATOR)[2] == "create"
+                )
+                group_key = (
+                    profile_value,
+                    params.get("new_profile_name", "") if is_create else "",
+                )
+                group = profile_groups.setdefault(
+                    group_key,
+                    {
+                        "params": params,
+                        "domains": [],
+                        "ids": [],
+                        "value_to_ids": {},
+                    },
+                )
+                group["ids"].append(id)
+                normalized = self.netskope_helper._normalize_csv_values(
+                    params.get("domain_names", "")
+                )
+                group["domains"].extend(normalized)
+                # Track which action id(s) each domain came from so that a
+                # domain that fails or is skipped (invalid/over-length or
+                # dropped under the payload budget) can be attributed back
+                # to the originating action(s) as a failed action id.
+                for value in normalized:
+                    group["value_to_ids"].setdefault(value, set()).add(id)
+            for group in profile_groups.values():
+                params = group["params"]
+                batch_ids = group["ids"]
+                value_to_ids = group["value_to_ids"]
+                domains = self.netskope_helper._normalize_csv_values(group["domains"])
+                profile_value = params.get("dns_profile_name", "")
+                # Safe to split on the first separator: a DNS profile
+                # name cannot contain "(" or ")" (rejected by both the
+                # Netskope DNS profile API and the plugin's save-time
+                # validation), so the "()" separator never collides with
+                # the name.
+                profile_name, _, profile_id = profile_value.partition(
+                    CUSTOM_SEPARATOR
+                )
+                existing_profile_name = (
+                    "create" if profile_id == "create" else profile_name
+                )
+                try:
+                    shared, not_applied = self._push_dns_profile(
+                        domains=domains,
+                        existing_profile_name=existing_profile_name,
+                        new_profile_name=params.get(
+                            "new_profile_name", ""
+                        ),
+                        action_type=params.get(
+                            "dns_profile_action_type", ""
+                        ),
+                        action_params=params,
+                        operation=params.get("operation", "append"),
+                    )
+                    self.netskope_helper._attribute_failed_ids(
+                        not_applied, value_to_ids, failed_action_ids
+                    )
+                    if params.get("operation", "append") == "replace":
+                        summary = (
+                            f"Successfully replaced the DNS profile's "
+                            f"domains for the selected record type(s) "
+                            f"with {shared} domain(s)."
+                        )
+                    else:
+                        summary = (
+                            f"Successfully added {shared} domain(s) to "
+                            "the DNS profile."
+                        )
+                    self.logger.info(f"{self.log_prefix}: {summary}")
+                except Exception as e:
+                    failed_action_ids.extend(batch_ids)
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: Error occurred while "
+                            "adding domains to the DNS profile. "
+                            f"Error: {e}"
+                        ),
+                        details=re.sub(
+                            r"token=([0-9a-zA-Z]*)",
+                            "token=********&",
+                            traceback.format_exc(),
+                        ),
+                    )
+            return ActionResult(
+                success=True,
+                message="Successfully added domains to DNS profiles.",
+                failed_action_ids=list(set(failed_action_ids)),
+            )
+        elif first_action.value == "service_profile":
+            profile_groups = {}
+            for action_dict in actions:
+                id, action = (
+                    action_dict.get("id"),
+                    action_dict.get("params"),
+                )
+                params = action.parameters
+                selected_profile = params.get("service_profile_name", "")
+                # new_profile_name only matters when creating a profile; for
+                # an existing profile it keeps a per-record source default,
+                # so exclude it to keep same-profile records in one group.
+                group_key = (
+                    selected_profile,
+                    params.get("new_profile_name", "")
+                    if selected_profile == "create"
+                    else "",
+                )
+                group = profile_groups.setdefault(
+                    group_key,
+                    {
+                        "params": params,
+                        "tcp": [],
+                        "udp": [],
+                        "tcp_udp": [],
+                        "ids": [],
+                        "value_to_ids": {},
+                    },
+                )
+                group["ids"].append(id)
+                # Track which action id(s) each port came from so that a
+                # port that fails or is skipped can be attributed back to
+                # the originating action(s) as a failed action id.
+                for proto_key in ("tcp_ports", "udp_ports", "tcp_udp_ports"):
+                    normalized = self.netskope_helper._normalize_csv_values(
+                        params.get(proto_key, "")
+                    )
+                    group[proto_key.replace("_ports", "")].extend(
+                        normalized
+                    )
+                    for value in normalized:
+                        group["value_to_ids"].setdefault(
+                            value, set()
+                        ).add(id)
+            for group in profile_groups.values():
+                params = group["params"]
+                batch_ids = group["ids"]
+                value_to_ids = group["value_to_ids"]
+                profile_name = params.get("service_profile_name", "")
+                if profile_name == "create":
+                    profile_name = params.get("new_profile_name", "")
+                try:
+                    _, not_applied = self._push_service_profile(
+                        operation=params.get("operation", "append"),
+                        profile_name=profile_name,
+                        description=params.get(
+                            "new_profile_description", ""
+                        ),
+                        tcp=self.netskope_helper._normalize_csv_values(group["tcp"]),
+                        udp=self.netskope_helper._normalize_csv_values(group["udp"]),
+                        tcp_udp=self.netskope_helper._normalize_csv_values(
+                            group["tcp_udp"]
+                        ),
+                        icmp=bool(params.get("icmp", False)),
+                    )
+                    self.netskope_helper._attribute_failed_ids(
+                        not_applied, value_to_ids, failed_action_ids
+                    )
+                    if params.get("operation", "append") == "replace":
+                        summary = (
+                            f"Successfully replaced the ports on the "
+                            f"service profile '{profile_name}'."
+                        )
+                    else:
+                        summary = (
+                            f"Successfully added ports to the service "
+                            f"profile '{profile_name}'."
+                        )
+                    self.logger.info(f"{self.log_prefix}: {summary}")
+                except Exception as e:
+                    failed_action_ids.extend(batch_ids)
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: Error occurred while "
+                            "adding ports to the service profile "
+                            f"'{profile_name}'. Error: {e}"
+                        ),
+                        details=re.sub(
+                            r"token=([0-9a-zA-Z]*)",
+                            "token=********&",
+                            traceback.format_exc(),
+                        ),
+                    )
+            return ActionResult(
+                success=True,
+                message="Successfully added ports to service profiles.",
+                failed_action_ids=list(set(failed_action_ids)),
+            )
+        elif first_action.value == "device_classification":
+            rule_groups = {}
+            for action_dict in actions:
+                id, action = (
+                    action_dict.get("id"),
+                    action_dict.get("params"),
+                )
+                params = action.parameters
+                classification_value = params.get(
+                    "device_classification", ""
+                )
+                rule_value = params.get("device_classification_rule", "")
+                # The create-name fields only matter when their dropdown is
+                # set to "create"; otherwise they keep a per-record source
+                # default, so exclude them from the key.
+                creating_classification = classification_value == "create"
+                creating_rule = (
+                    rule_value.rpartition(
+                        CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION
+                    )[2] == "create"
+                )
+                group_key = (
+                    params.get("operation", ""),
+                    classification_value,
+                    params.get("new_classification_name", "")
+                    if creating_classification
+                    else "",
+                    rule_value,
+                    params.get("new_rule_name", "")
+                    if creating_rule
+                    else "",
+                    params.get("os", ""),
+                    params.get("logical_operator", ""),
+                    params.get("group_operator", ""),
+                )
+                group = rule_groups.setdefault(
+                    group_key,
+                    {
+                        "params": params,
+                        "tags": [],
+                        "ids": [],
+                        "value_to_ids": {},
+                    },
+                )
+                group["ids"].append(id)
+                normalized = self.netskope_helper._normalize_csv_values(
+                    params.get("classification_tags", "")
+                )
+                group["tags"].extend(normalized)
+                # Track which action id(s) each device tag came from so a
+                # tag that is skipped (no matching tag on the tenant) can
+                # be attributed back to the originating action(s).
+                for value in normalized:
+                    group["value_to_ids"].setdefault(
+                        value, set()
+                    ).add(id)
+            rule_action_statuses = set()
+            for group in rule_groups.values():
+                params = group["params"]
+                batch_ids = group["ids"]
+                value_to_ids = group["value_to_ids"]
+                tags = self.netskope_helper._normalize_csv_values(group["tags"])
+                try:
+                    _, not_applied, action_status = (
+                        self._push_device_classification(
+                            operation=params.get("operation", "append"),
+                            classification_value=params.get(
+                                "device_classification", ""
+                            ),
+                            new_classification_name=params.get(
+                                "new_classification_name", ""
+                            ),
+                            rule_value=params.get(
+                                "device_classification_rule", ""
+                            ),
+                            new_rule_name=params.get("new_rule_name", ""),
+                            os=params.get("os", ""),
+                            operator=params.get(
+                                "logical_operator", "and"
+                            ),
+                            group_operator=params.get(
+                                "group_operator", "and"
+                            ),
+                            tags=tags,
+                        )
+                    )
+                    rule_action_statuses.add(action_status)
+                    self.netskope_helper._attribute_failed_ids(
+                        not_applied, value_to_ids, failed_action_ids
+                    )
+                    self.logger.info(
+                        f"{self.log_prefix}: Successfully {action_status} "
+                        "the device classification rule."
+                    )
+                except Exception as e:
+                    failed_action_ids.extend(batch_ids)
+                    self.logger.error(
+                        message=(
+                            f"{self.log_prefix}: Error occurred while "
+                            "creating or updating the device "
+                            f"classification rule. Error: {e}"
+                        ),
+                        details=str(traceback.format_exc()),
+                    )
+            # Build the aggregate verb from what actually happened across
+            # the groups: only-created, only-updated, or a mix of both.
+            if rule_action_statuses == {"created"}:
+                status_verb = "created"
+            elif rule_action_statuses == {"updated"}:
+                status_verb = "updated"
+            elif rule_action_statuses:
+                status_verb = "created and updated"
+            else:
+                status_verb = "created or updated"
+            return ActionResult(
+                success=True,
+                message=(
+                    f"Successfully {status_verb} device classification "
+                    "rule(s)."
+                ),
+                failed_action_ids=list(set(failed_action_ids)),
+            )
         elif first_action.value == "generate":
             self.logger.info(
                 f"{self.log_prefix}: Successfully performed action "
@@ -6333,5 +12077,3 @@ class NetskopePlugin(PluginBase):
                 "tagged": tagged_count
             }
         return tags_apps_info, batch_failed_action_ids
-
-    # TODO: Implement cleanup method to delete client status iterator

--- a/netskope_ztre/manifest.json
+++ b/netskope_ztre/manifest.json
@@ -1,12 +1,12 @@
 {
     "name": "Netskope Risk Exchange",
-    "description": "This plugin is used to fetch Users from UBA Alerts, Applications from Applications Events, and Devices from Client Status Events of the Netskope Tenant. This plugin also supports 'Add user to group', 'Remove user from group', 'Update UCI score', 'UCI Reset', 'Add host to Private App', 'Create or Update App Instance', 'Tag/Untag Application', 'Tag/Untag Device', 'No Action' and 'Mark Anomaly as allowed' is also supported for 'Update UCI score' action.",
+    "description": "This plugin is used to fetch Users from UBA Alerts, Applications from Applications Events, and Devices from Client Status Events of the Netskope Tenant. This plugin also supports 'Add user to group', 'Remove user from group', 'Update UCI score', 'UCI Reset', 'Add host to Private App', 'Create or Update App Instance', 'Tag/Untag Application', 'Tag/Untag Device', 'Add to Destination Profile', 'Add to DNS Profile', 'Add to Service Profile', 'Create Device Classification', 'No Action' and 'Mark Anomaly as allowed' is also supported for 'Update UCI score' action.",
     "id": "netskope_ztre",
     "minimum_version": "6.1.0",
-    "minimum_provider_version": "1.4.0",
+    "minimum_provider_version": "1.6.1",
     "provider_id": "netskope_provider",
     "netskope": true,
-    "version": "1.7.0",
+    "version": "1.8.0",
     "module": "CRE",
     "supported_subtypes": {
         "alerts": [

--- a/netskope_ztre/utils/constants.py
+++ b/netskope_ztre/utils/constants.py
@@ -36,6 +36,13 @@ DEFAULT_WAIT_TIME = 60
 DEVICE_BULK_TAG_INTER_BATCH_SLEEP = 12
 PAGE_SIZE = 100
 MAX_HOSTS_PER_PRIVATE_APP = 500
+# Private app host IPv4 CIDR blocks wider than /8 (prefix < 8) are rejected;
+# 0.0.0.0/0 is wider than /8 and is therefore rejected by the same check.
+PRIVATE_APP_MIN_CIDR_PREFIX = 8
+# A single hostname label: 1-63 chars of letters/digits/hyphen/underscore,
+# not starting or ending with a hyphen. Used to validate private app
+# host/domain labels.
+REGEX_HOSTNAME_LABEL = r"^(?!-)[a-zA-Z0-9_-]{1,63}(?<!-)$"
 USERS_BATCH_SIZE = 512
 APPLICATIONS_BATCH_SIZE = 100
 REGEX_HOST = (
@@ -44,9 +51,17 @@ REGEX_HOST = (
 )
 REGEX_EMAIL = r"[^@]+@[^@]+\.[^@]+"
 REGEX_TAG = r"^[a-zA-Z0-9- ]*$"
+# Anchored with ``\Z`` (not ``$``): in Python ``$`` also matches just
+# before a trailing newline, so a value like "example.com\n" would
+# otherwise be accepted as a valid domain. ``\Z`` matches only the very
+# end of the string.
+REGEX_FOR_DOMAIN = (
+    r"^(?!.{254})(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+"
+    r"(?:[a-zA-Z]{2,63})\Z"
+)
 MODULE_NAME = "CRE"
 PLUGIN = "Netskope Risk Exchange"
-PLUGIN_VERSION = "1.7.0"
+PLUGIN_VERSION = "1.8.0"
 URLS = {
     "V2_PRIVATE_APP": "/api/v2/steering/apps/private",
     "V2_PRIVATE_APP_PATCH": "/api/v2/steering/apps/private/{}",
@@ -67,7 +82,22 @@ URLS = {
     "V2_CCI_TAGS": "/api/v2/services/cci/tags",
     "V2_UCI_IMPACT": "/api/v2/incidents/user/uciimpact",
     "V2_GET_UCI": "/api/v2/incidents/uba/getuci",
-    "V2_REVERT_UCI_IMPACT": "/api/v2/incidents/anomalies/{}/allow"
+    "V2_REVERT_UCI_IMPACT": "/api/v2/incidents/anomalies/{}/allow",
+    "V2_DESTINATION_PROFILE": "/api/v2/profiles/destinations",
+    "V2_DESTINATION_PROFILE_BY_ID": "/api/v2/profiles/destinations/{}",
+    "V2_DESTINATION_PROFILE_VALUES": (
+        "/api/v2/profiles/destinations/{}/values"
+    ),
+    "V2_DESTINATION_PROFILE_DEPLOY": "/api/v2/profiles/destinations/deploy",
+    "V2_DNS_PROFILE": "/api/v2/profiles/dns",
+    "V2_DNS_PROFILE_BY_ID": "/api/v2/profiles/dns/{}",
+    "V2_DNS_DOMAIN_CATEGORIES": "/api/v2/profiles/dns/domaincategories",
+    "V2_DNS_RECORD_TYPES": "/api/v2/profiles/dns/recordtypes",
+    "V2_DEVICE_CLASSIFICATION_TAGS": "/api/v2/deviceclassification/tags",
+    "V2_DEVICE_CLASSIFICATION_RULES": "/api/v2/deviceclassification/rules",
+    "V2_DEVICE_CLASSIFICATION_RULE_BY_ID": (
+        "/api/v2/deviceclassification/rules/{}"
+    ),
 }
 ERROR_TAG_EXISTS = (
     "Tag provided is already present. Hence use PATCH method to add "
@@ -83,6 +113,7 @@ APP_INSTANCE_BATCH_SIZE = 500
 TAG_APP_BATCH_SIZE = 100
 TAG_APP_TAG_LENGTH = 75
 TAG_DEVICE_TAG_LENGTH = 80
+PRIVATE_APP_TAG_MAX_LENGTH = 30
 TAG_DEVICE_BATCH_SIZE = 1000
 MAX_TAGS_PER_DEVICE = 5
 TAG_CACHE_PAGE_SIZE = 10
@@ -132,3 +163,667 @@ TAG_ACTION_LABEL_MAP = {
     "append": "Add",
     "remove": "Remove"
 }
+
+# ---------------------------------------------------------------------------
+# Add to Destination Profile action constants
+# ---------------------------------------------------------------------------
+# Capacity limits enforced by Netskope for destination profiles.
+DESTINATION_PROFILE_EXACT_TOTAL_LIMIT = 300000
+DESTINATION_PROFILE_EXACT_PER_PROFILE_LIMIT = 100000
+DESTINATION_PROFILE_REGEX_TOTAL_LIMIT = 1000
+# Destination profile by-id PATCH request body byte budget with a safety
+# buffer. The by-id PATCH carries the match type/description and the full
+# value list, and a body larger than this is rejected, so a value set
+# that does not fit is split across a first by-id PATCH and one or more
+# appends on the values endpoint. NOTE: this size budget applies ONLY to
+# the by-id PATCH (and the create POST). The values-endpoint append is
+# bounded by a value COUNT, not by payload size (see
+# DESTINATION_PROFILE_VALUES_PER_APPEND).
+# IMPORTANT: the real enforced limit is 9 MB, not the documented 10 MB --
+# a 10 MB body is rejected by the API. Do NOT raise this to 10 * 1024 *
+# 1024.
+DESTINATION_PROFILE_PAYLOAD_LIMIT = 9 * 1024 * 1024
+DESTINATION_PROFILE_PAYLOAD_SAFETY_BUFFER = 1024
+# The destination profile values endpoint (PATCH with op "append")
+# accepts at most this many values per call, so overflow values are
+# appended in batches of this size.
+DESTINATION_PROFILE_VALUES_PER_APPEND = 10
+# Destination profile name/description length limits.
+MAX_DESTINATION_PROFILE_NAME_LENGTH = 100
+MAX_DESTINATION_PROFILE_DESC_LENGTH = 200
+# Characters not allowed in a destination profile name.
+DESTINATION_PROFILE_NAME_FORBIDDEN_CHARS = ['"', ";"]
+# Allowed match types for a destination profile.
+MATCH_TYPE_OPTIONS = {
+    "insensitive": "Case Insensitive",
+    "sensitive": "Case Sensitive",
+    "regex": "Regex",
+}
+# Substring returned by the API when a profile has undeployed changes.
+PENDING_CHANGES_DETECTED = (
+    "non-interactive operation on pending profile is not allowed"
+)
+
+# ---------------------------------------------------------------------------
+# Add to DNS Profile action constants
+# ---------------------------------------------------------------------------
+# DNS profile name/description length limits.
+MAX_DNS_PROFILE_NAME_LENGTH = 255
+MAX_DNS_PROFILE_DESC_LENGTH = 255
+# Characters not allowed in a DNS profile name or description.
+DNS_PROFILE_FORBIDDEN_CHARS = ["(", ")", '"']
+# DNS profile payload byte budget (16 MiB) with a safety buffer.
+DNS_PROFILE_PAYLOAD_LIMIT = 16 * 1024 * 1024
+DNS_PROFILE_PAYLOAD_SAFETY_BUFFER = 1024
+# Allowed action types when adding domains to a DNS profile.
+DNS_PROFILE_ACTION_TYPE_OPTIONS = {
+    "add_to_allow_list": "Add to Domain Allowlist",
+    "add_to_block_list": "Add to Domain Blocklist",
+}
+# Allowed values for the "Block all except Allow list" choice.
+BLOCK_ALL_EXCEPT_ALLOW_LIST_OPTIONS = {
+    "True": "Yes",
+    "False": "No",
+}
+# Separator used to pack DNS profile name and id into a choice value
+# (DNS profile names cannot contain these characters).
+CUSTOM_SEPARATOR = "()"
+# Page size used when paginating DNS profile listings/categories.
+DNS_PROFILE_PAGE_SIZE = 150
+
+# ---------------------------------------------------------------------------
+# Add to Service Profile action constants
+# ---------------------------------------------------------------------------
+# API endpoint paths (URL is built as f"{tenant}{path}").
+V2_SERVICE_PROFILE = "/api/v2/profiles/serviceobjects"
+V2_SERVICE_PROFILE_BY_ID = "/api/v2/profiles/serviceobjects/{}"
+# Allowed operations when adding data to a profile (append keeps the
+# existing data and adds to it, replace overwrites it with the new
+# data). Shared by the destination, DNS and service profile actions.
+OPERATION_OPTIONS = {
+    "replace": "Replace",
+    "append": "Append",
+}
+# Alias retained for the service profile action.
+SERVICE_PROFILE_OPERATION_OPTIONS = OPERATION_OPTIONS
+# Service profile name/description length limits.
+MAX_SERVICE_PROFILE_NAME_LENGTH = 255
+MAX_SERVICE_PROFILE_DESC_LENGTH = 512
+# Only CUSTOM service profiles are editable (PREDEFINED are read-only).
+SERVICE_PROFILE_TYPE_CUSTOM = "CUSTOM"
+# Page size used when paginating service profile listings.
+SERVICE_PROFILE_PAGE_SIZE = 150
+
+# ---------------------------------------------------------------------------
+# Create Device Classification action constants
+# ---------------------------------------------------------------------------
+# Page size used when paginating device classification tag/rule listings.
+DEVICE_CLASSIFICATION_PAGE_SIZE = 1000
+# Name length limit for a device classification and its rule.
+MAX_DEVICE_CLASSIFICATION_NAME_LENGTH = 80
+# Separator used to pack "name<sep>id" in the device classification rule
+# dropdown. A dedicated separator (not the shared CUSTOM_SEPARATOR "()") is
+# used because device classification and rule names are allowed to contain
+# "()", so it cannot serve as a delimiter here.
+CUSTOM_SEPARATOR_DEVICE_CLASSIFICATION = "@#!<>"
+# Default description used when creating a device classification.
+DEVICE_CLASSIFICATION_DEFAULT_DESCRIPTION = "Created from Netskope CE."
+# Maximum number of device tags allowed in a single condition group of a
+# device classification rule. When a rule references more device tags than
+# this, the tags are split across multiple groups joined by the selected
+# logical operator.
+DEVICE_CLASSIFICATION_TAGS_PER_GROUP = 5
+# Maximum number of device tags an action may apply to a rule (the rule total).
+# Tags beyond this count (by position, after de-duplication) are ignored: they
+# are not validated, not resolved, and not sent. For an Append, the new tags
+# only fill the rule up to this total; a rule already holding this many tags
+# skips the append entirely.
+MAX_DEVICE_CLASSIFICATION_TAGS = 5
+# Allowed operating systems for a device classification rule (the key is
+# the value sent to the API, the value is the display label).
+DEVICE_CLASSIFICATION_OS_OPTIONS = {
+    "windows": "Windows",
+    "winserver": "Windows Server",
+    "mac": "macOS",
+    "android": "Android",
+    "ios": "iOS",
+    "chromeos": "ChromeOS",
+    "linux": "Linux",
+}
+# Allowed logical operators for combining device tags in a rule. The key is
+# the value stored on the action; it is mapped to the API's "$and"/"$or"
+# condition operator at build time (stored without the "$" so it is not
+# mistaken for a Source field reference during validation).
+DEVICE_CLASSIFICATION_OPERATOR_OPTIONS = {
+    "and": "All",
+    "or": "Any",
+}
+
+# ---------------------------------------------------------------------------
+# Action parameter templates
+# ---------------------------------------------------------------------------
+# Static field definitions for the actions added in this release. They are
+# deep-copied in ``get_action_params`` and the fields whose ``choices`` (and
+# in some cases ``default``) depend on live API responses are populated
+# there by parameter ``key``:
+#   - destination_profile -> "destination_profile_name"
+#   - dns_profile         -> "dns_profile_name", "dns_security_categories",
+#                            "dns_record_types"
+#   - service_profile     -> "service_profile_name"
+#   - device_classification -> "device_classification",
+#                              "device_classification_rule"
+DESTINATION_PROFILE_ACTION_PARAMS = [
+    {
+        "label": "Operation",
+        "key": "operation",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in OPERATION_OPTIONS.items()
+        ],
+        "default": "append",
+        "mandatory": True,
+        "description": (
+            "Select whether to append the values to the existing values or"
+            " replace the current values with new values on the profile."
+            " Select from the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Destination Profile",
+        "key": "destination_profile_name",
+        "type": "choice",
+        "choices": [],
+        "default": "",
+        "mandatory": True,
+        "description": (
+            "Select an existing destination profile from the Static "
+            "field dropdown or select 'Create new profile'."
+        ),
+    },
+    {
+        "label": "Create New Profile",
+        "key": "new_profile_name",
+        "type": "text",
+        "default": "",
+        "mandatory": False,
+        "description": (
+            "Name of the destination profile to create. Provide the "
+            "name in the Static field only if 'Create new profile' is "
+            "selected in Destination Profile. The profile name should "
+            f"not exceed {MAX_DESTINATION_PROFILE_NAME_LENGTH} "
+            "characters and it cannot contain '\"' (Double Quotes) or"
+            " ';' (Semicolon)."
+        ),
+    },
+    {
+        "label": "Profile Description",
+        "key": "new_profile_description",
+        "type": "text",
+        "default": "Created from Netskope CE.",
+        "mandatory": False,
+        "description": (
+            "Description for the destination profile. It will add or replace"
+            " the current description with provided. The description should"
+            " not exceed {MAX_DESTINATION_PROFILE_DESC_LENGTH} characters."
+        ),
+    },
+    {
+        "label": "Match Type",
+        "key": "profile_match_type",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in MATCH_TYPE_OPTIONS.items()
+        ],
+        "default": "insensitive",
+        "mandatory": False,
+        "description": (
+            "Match type for the destination profile. Select from the "
+            "Static field dropdown only. It will add or replace the current"
+            " match type with the provided value."
+        ),
+    },
+    {
+        "label": "Apply Pending Changes",
+        "key": "apply_pending_changes",
+        "type": "choice",
+        "choices": [
+            {"key": "Yes", "value": "Yes"},
+            {"key": "No", "value": "No"},
+        ],
+        "default": "No",
+        "mandatory": True,
+        "description": (
+            "Select 'Yes' to deploy pending changes and retry when the "
+            "destination profile has undeployed changes. Select from "
+            "the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Network Targets",
+        "key": "destination_values",
+        "type": "text",
+        "default": "",
+        "placeholder": "i.e. 10.0.0.1, example.com",
+        "mandatory": True,
+        "description": (
+            "Select a Source field for the destination values or "
+            "provide Static comma-separated values, IPs, or URLs to "
+            "add to the profile."
+        ),
+    },
+    {
+        "label": "Tenant Exact-Match Value Limit",
+        "key": "exact_match_total_limit",
+        "type": "number",
+        "default": DESTINATION_PROFILE_EXACT_TOTAL_LIMIT,
+        "mandatory": False,
+        "description": (
+            "Maximum number of exact-match (Case Insensitive / Case "
+            "Sensitive) values allowed tenant-wide, used as the capacity "
+            "ceiling when adding values to a profile. Provide a positive "
+            "integer in the Static field only. The default tenant limit is"
+            f" {DESTINATION_PROFILE_EXACT_TOTAL_LIMIT}. If you have increased"
+            " limit enter that value here. Leave empty to use the "
+            f"default of {DESTINATION_PROFILE_EXACT_TOTAL_LIMIT}."
+        ),
+    },
+]
+
+DNS_PROFILE_ACTION_PARAMS = [
+    {
+        "label": "Operation",
+        "key": "operation",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in OPERATION_OPTIONS.items()
+        ],
+        "default": "append",
+        "mandatory": True,
+        "description": (
+            "Select whether to append the values to the existing values or"
+            " replace the current values with new values on the profile."
+            " Select from the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Action Type",
+        "key": "dns_profile_action_type",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in DNS_PROFILE_ACTION_TYPE_OPTIONS.items()
+        ],
+        "default": "add_to_allow_list",
+        "mandatory": True,
+        "description": (
+            "Whether to add the domains to the allow list or the block "
+            "list of the DNS profile. Select from the Static field "
+            "dropdown only."
+        ),
+    },
+    {
+        "label": "DNS Profile",
+        "key": "dns_profile_name",
+        "type": "choice",
+        "choices": [],
+        "default": "",
+        "mandatory": True,
+        "description": (
+            "Select an existing DNS profile from the Static field "
+            "dropdown or select 'Create new DNS Profile'."
+        ),
+    },
+    {
+        "label": "Create New DNS Profile",
+        "key": "new_profile_name",
+        "type": "text",
+        "default": "",
+        "mandatory": False,
+        "description": (
+            "Name of the DNS profile to create. Provide the name in "
+            "the Static field only if 'Create new DNS Profile' is "
+            "selected in DNS Profile. The profile name should not exceed "
+            f"{MAX_DNS_PROFILE_NAME_LENGTH} characters and it cannot contain"
+            " '(', ')' or '\"'."
+        ),
+    },
+    {
+        "label": "Profile Description",
+        "key": "new_profile_description",
+        "type": "text",
+        "default": "Created from Netskope CE.",
+        "mandatory": False,
+        "description": (
+            "Description for the DNS profile to be created. Used only "
+            "when 'Create new DNS Profile' is selected in DNS Profile. "
+            f"The description should not exceed {MAX_DNS_PROFILE_DESC_LENGTH}"
+            " characters"
+        ),
+    },
+    {
+        "label": "Categories",
+        "key": "dns_security_categories",
+        "type": "multichoice",
+        "choices": [],
+        "default": [],
+        "mandatory": False,
+        "description": (
+            "Select the security categories to apply on the DNS profile"
+            " from the Static field dropdown only. The same category cannot"
+            " be selected with both 'Block' and 'Sinkhole' actions."
+            " Selecting any 'Sinkhole' variant requires a value in the"
+            " 'Sinkhole IP' parameter."
+        ),
+    },
+    {
+        "label": "Sinkhole IP",
+        "key": "sinkhole_ip",
+        "type": "text",
+        "default": "",
+        "mandatory": False,
+        "description": (
+            "Sinkhole IP address for the DNS profile. Required only "
+            "when a '(Sinkhole)' category is selected in Categories. "
+            "Provide in the Static field only."
+        ),
+    },
+    {
+        "label": "Record Types",
+        "key": "dns_record_types",
+        "type": "multichoice",
+        "choices": [],
+        "default": [],
+        "mandatory": True,
+        "description": (
+            "Select the DNS record types from the Static field dropdown."
+            " The 'All Record Types' value cannot be selected together with"
+            " any other Record Type value."
+        ),
+    },
+    {
+        "label": "Block all except Allow list",
+        "key": "block_all_except_allow_list",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in BLOCK_ALL_EXCEPT_ALLOW_LIST_OPTIONS.items()
+        ],
+        "default": "False",
+        "mandatory": True,
+        "description": (
+            "Select 'Yes' to block all domains except those on the "
+            "allow list. Select from the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Domain Names",
+        "key": "domain_names",
+        "type": "text",
+        "default": "",
+        "placeholder": "i.e. example.com, test.org",
+        "mandatory": True,
+        "description": (
+            "Select a Source field for the domain names or provide "
+            "Static comma-separated domains or FQDNs to add to the DNS "
+            "profile."
+        ),
+    },
+]
+
+SERVICE_PROFILE_ACTION_PARAMS = [
+    {
+        "label": "Operation",
+        "key": "operation",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in SERVICE_PROFILE_OPERATION_OPTIONS.items()
+        ],
+        "default": "append",
+        "mandatory": True,
+        "description": (
+            "Select whether to append the values to the existing values or"
+            " replace the current values with new values on the profile."
+            " Select from the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Service Profile",
+        "key": "service_profile_name",
+        "type": "choice",
+        "choices": [],
+        "default": "",
+        "mandatory": True,
+        "description": (
+            "Select an existing custom service profile from the Static "
+            "field dropdown or select 'Create new service profile'. "
+            "Only custom (editable) profiles are listed."
+        ),
+    },
+    {
+        "label": "Service Profile Name",
+        "key": "new_profile_name",
+        "type": "text",
+        "default": "",
+        "mandatory": False,
+        "description": (
+            "Name of the service profile to create. Provide the name "
+            "in the Static field only if 'Create new service profile' "
+            "is selected in Service Profile. The profile name should "
+            f"not exceed {MAX_SERVICE_PROFILE_NAME_LENGTH} characters."
+        ),
+    },
+    {
+        "label": "Description",
+        "key": "new_profile_description",
+        "type": "text",
+        "default": "Created from Netskope CE.",
+        "mandatory": False,
+        "description": (
+            "Description for the service profile to be created. Used "
+            "only when 'Create new service profile' is selected in "
+            "Service Profile. The description should not exceed "
+            f"{MAX_SERVICE_PROFILE_DESC_LENGTH} characters."
+        ),
+    },
+    {
+        "label": "TCP Ports",
+        "key": "tcp_ports",
+        "type": "text",
+        "default": "",
+        "placeholder": "i.e. 443, 8080-8090",
+        "mandatory": False,
+        "description": (
+            "Select a Source field for the TCP ports or provide Static "
+            "comma-separated ports or port ranges (e.g. 9000-9500)."
+        ),
+    },
+    {
+        "label": "UDP Ports",
+        "key": "udp_ports",
+        "type": "text",
+        "default": "",
+        "placeholder": "i.e. 53, 8080-8090",
+        "mandatory": False,
+        "description": (
+            "Select a Source field for the UDP ports or provide Static "
+            "comma-separated ports or port ranges (e.g. 9000-9500)."
+        ),
+    },
+    {
+        "label": "TCP/UDP Ports",
+        "key": "tcp_udp_ports",
+        "type": "text",
+        "default": "",
+        "placeholder": "i.e. 443, 8080-8090",
+        "mandatory": False,
+        "description": (
+            "Select a Source field for the TCP_UDP ports or provide "
+            "Static comma-separated ports or port ranges "
+            "(e.g. 9000-9500)."
+        ),
+    },
+    {
+        "label": "ICMP",
+        "key": "icmp",
+        "type": "choice",
+        "choices": [
+            {"key": "No", "value": False},
+            {"key": "Yes", "value": True},
+        ],
+        "default": False,
+        "mandatory": False,
+        "description": (
+            "Select 'Yes' to enable the ICMP protocol on the service "
+            "profile. Select from the Static field dropdown only."
+        ),
+    },
+]
+
+DEVICE_CLASSIFICATION_ACTION_PARAMS = [
+    {
+        "label": "Operation",
+        "key": "operation",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in OPERATION_OPTIONS.items()
+        ],
+        "default": "append",
+        "mandatory": True,
+        "description": (
+            "Select whether to append the values to the existing values or"
+            " replace the current values with new values on the rule."
+            " Select from the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Device Classification",
+        "key": "device_classification",
+        "type": "choice",
+        "choices": [],
+        "default": "",
+        "mandatory": True,
+        "description": (
+            "Select an existing device classification from the Static "
+            "field dropdown to use as the rule's classification, or "
+            "select 'Create new Device Classification'."
+        ),
+    },
+    {
+        "label": "Device Classification Name",
+        "key": "new_classification_name",
+        "type": "text",
+        "default": "",
+        "mandatory": False,
+        "description": (
+            "Name of the device classification to create. Provide the "
+            "name in the Static field only if 'Create new Device "
+            "Classification' is selected in Device Classification. The "
+            "name should not exceed "
+            f"{MAX_DEVICE_CLASSIFICATION_NAME_LENGTH} characters."
+        ),
+    },
+    {
+        "label": "Device Classification Rule",
+        "key": "device_classification_rule",
+        "type": "choice",
+        "choices": [],
+        "default": "",
+        "mandatory": True,
+        "description": (
+            "Select an existing device classification rule to update "
+            "from the Static field dropdown, or select 'Create new "
+            "Device Classification Rule'."
+        ),
+    },
+    {
+        "label": "Device Classification Rule Name",
+        "key": "new_rule_name",
+        "type": "text",
+        "default": "",
+        "mandatory": False,
+        "description": (
+            "Name of the device classification rule to create. Provide "
+            "the name in the Static field only if 'Create new Device "
+            "Classification Rule' is selected in Device Classification "
+            "Rule. The rule name should not exceed "
+            f"{MAX_DEVICE_CLASSIFICATION_NAME_LENGTH} characters."
+        ),
+    },
+    {
+        "label": "Operating System",
+        "key": "os",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in DEVICE_CLASSIFICATION_OS_OPTIONS.items()
+        ],
+        "default": "windows",
+        "mandatory": True,
+        "description": (
+            "Target operating system for the device classification "
+            "rule. Select from the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Match Type",
+        "key": "logical_operator",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in DEVICE_CLASSIFICATION_OPERATOR_OPTIONS.items()
+        ],
+        "default": "and",
+        "mandatory": True,
+        "description": (
+            "Select the Match Type (Logical Operator) to be applied on the"
+            "tags in the Device Classification Rule. Select from the Static"
+            " field dropdown only."
+        ),
+    },
+    {
+        "label": "Group Match Type",
+        "key": "group_operator",
+        "type": "choice",
+        "choices": [
+            {"key": value, "value": key}
+            for key, value in DEVICE_CLASSIFICATION_OPERATOR_OPTIONS.items()
+        ],
+        "default": "and",
+        "mandatory": True,
+        "description": (
+            "Select how the top-level condition groups are combined in"
+            " the Device Classification Rule. 'All' requires every"
+            " group to match; 'Any' requires at least one group to"
+            " match. Takes effect when more than"
+            f" {DEVICE_CLASSIFICATION_TAGS_PER_GROUP} tags are provided"
+            " (creating multiple tag groups) or when the existing rule"
+            " already contains multiple condition groups. Select from"
+            " the Static field dropdown only."
+        ),
+    },
+    {
+        "label": "Tags",
+        "key": "classification_tags",
+        "type": "text",
+        "default": "",
+        "placeholder": "i.e. tag1, tag2",
+        "mandatory": True,
+        "description": (
+            "Select a Source field for the device tags or provide "
+            "Static comma-separated device tag names to use in the "
+            "rule conditions. If more than "
+            f"{DEVICE_CLASSIFICATION_TAGS_PER_GROUP} tags are provided,"
+            " they are split into groups of "
+            f"{DEVICE_CLASSIFICATION_TAGS_PER_GROUP} and each group"
+            " becomes a separate condition block in the rule. For an"
+            " Append, new tags are unioned with the existing ones and"
+            " the result is re-grouped. Each tag must already exist on"
+            " the Netskope Tenant."
+        ),
+    },
+]

--- a/netskope_ztre/utils/helper.py
+++ b/netskope_ztre/utils/helper.py
@@ -31,10 +31,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Netskope CRE plugin helper module."""
 
+import copy
+import json
+import ipaddress
+import re
 import requests
 import time
 import traceback
-from typing import Dict
+from typing import Dict, List, Optional, Tuple, Union
 
 from netskope.common.utils import (
     add_installation_id,
@@ -44,10 +48,30 @@ from netskope.common.utils.handle_exception import (
     handle_exception,
     handle_status_code,
 )
+from netskope.integrations.crev2.plugin_base import ValidationResult
 from .constants import (
     DEFAULT_WAIT_TIME,
+    DESTINATION_PROFILE_EXACT_TOTAL_LIMIT,
+    DESTINATION_PROFILE_EXACT_PER_PROFILE_LIMIT,
+    DESTINATION_PROFILE_REGEX_TOTAL_LIMIT,
+    DEVICE_CLASSIFICATION_TAGS_PER_GROUP,
     MAX_RETRY_COUNT,
+    PRIVATE_APP_MIN_CIDR_PREFIX,
+    PRIVATE_APP_TAG_MAX_LENGTH,
+    REGEX_HOSTNAME_LABEL,
+    REGEX_TAG,
+    TAG_DEVICE_TAG_LENGTH,
 )
+
+
+def _capitalize_first(text: str) -> str:
+    """Upper-case only the first character, preserving the rest's casing.
+
+    Used for log messages instead of ``str.capitalize()``, which also
+    lower-cases the remainder and would mangle interpolated values such as
+    profile, classification, app or tag names.
+    """
+    return text[:1].upper() + text[1:]
 
 
 class NetskopeException(Exception):
@@ -77,6 +101,25 @@ class NetskopePluginHelper(object):
         self.log_prefix = log_prefix
         self.logger = logger
 
+    def is_valid_domain_length(self, domain: str) -> bool:
+        """Check whether a domain name meets RFC length limits.
+
+        Total length must not exceed 253 characters and each label
+        (between dots) must be 1-63 characters.
+
+        Args:
+            domain (str): Domain name to validate.
+
+        Returns:
+            bool: True if the domain satisfies the RFC length limits,
+                False otherwise.
+        """
+        if not domain or len(domain) > 253:
+            return False
+        return all(
+            label and len(label) <= 63 for label in domain.split(".")
+        )
+
     def _get_retry_after(self, headers) -> int:
         """
         Get the retry after value from the headers.
@@ -87,7 +130,14 @@ class NetskopePluginHelper(object):
         Returns:
             int: Retry after value.
         """
-        return int(headers.get("Retry-After", DEFAULT_WAIT_TIME))
+        try:
+            if retry_after := headers.get("Retry-After"):
+                return int(retry_after)
+            if retry_after := headers.get("RateLimit-Reset"):
+                return int(retry_after)
+            return DEFAULT_WAIT_TIME
+        except Exception:
+            return DEFAULT_WAIT_TIME
 
     def _api_call_helper(
         self,
@@ -128,6 +178,7 @@ class NetskopePluginHelper(object):
                     json=json,
                     params=params,
                     proxies=proxies,
+                    timeout=300,
                 )
                 if not success:
                     raise response
@@ -203,3 +254,1244 @@ class NetskopePluginHelper(object):
                 details=traceback.format_exc(),
             )
             raise NetskopeException(err_msg)
+
+    # ------------------------------------------------------------------
+    # Shared validation helpers
+    # ------------------------------------------------------------------
+
+    def _validate_max_length(
+        self,
+        field_name: str,
+        field_value: str,
+        max_length: int,
+    ) -> Union[ValidationResult, None]:
+        """Validate that a field value does not exceed max_length.
+
+        Args:
+            field_name (str): Display name of the field.
+            field_value (str): Value to validate.
+            max_length (int): Maximum allowed character count.
+
+        Returns:
+            ValidationResult on failure, None when valid.
+        """
+        if len(field_value) > max_length:
+            err_msg = (
+                f"'{field_name}' should be less than or equal"
+                f" to {max_length} characters."
+            )
+            self.logger.error(
+                message=f"{self.log_prefix}: {err_msg}",
+                resolution=(
+                    f"Ensure that '{field_name}' does not"
+                    f" exceed {max_length} characters."
+                ),
+            )
+            return ValidationResult(success=False, message=err_msg)
+        return None
+
+    def _validate_forbidden_chars(
+        self,
+        field_name: str,
+        field_value: str,
+        forbidden_chars,
+    ) -> Union[ValidationResult, None]:
+        """Validate that a field value contains no forbidden characters.
+
+        Args:
+            field_name (str): Display name of the field.
+            field_value (str): Value to validate.
+            forbidden_chars: Iterable of single characters to reject.
+
+        Returns:
+            ValidationResult on failure, None when valid.
+        """
+        if any(char in field_value for char in forbidden_chars):
+            chars_str = ", ".join(
+                f"'{c}'" for c in forbidden_chars
+            )
+            err_msg = (
+                f"'{field_name}' should not contain"
+                f" {chars_str} characters."
+            )
+            self.logger.error(
+                message=f"{self.log_prefix}: {err_msg}",
+                resolution=(
+                    f"Ensure that '{field_name}' does not"
+                    f" contain {chars_str}."
+                ),
+            )
+            return ValidationResult(success=False, message=err_msg)
+        return None
+
+    def _validate_ip_address(self, value: str) -> bool:
+        """Return True if value is a valid IP address.
+
+        Args:
+            value (str): String to validate.
+
+        Returns:
+            bool: True if valid IP, False otherwise.
+        """
+        try:
+            ipaddress.ip_address(value)
+            return True
+        except ValueError:
+            return False
+
+    # ------------------------------------------------------------------
+    # Shared execution utilities
+    # ------------------------------------------------------------------
+
+    def _normalize_csv_values(
+        self, raw_value: Union[str, list]
+    ) -> List[str]:
+        """Normalize a Source/Static value field into a value list.
+
+        A Source field resolves to either a list (already split) or a
+        comma-separated string; a Static field is a comma-separated
+        string. This trims whitespace, drops empty entries, and
+        de-duplicates while preserving the original order.
+
+        Args:
+            raw_value (Union[str, list]): Resolved field value, either
+                a list or a comma-separated string.
+
+        Returns:
+            List[str]: Cleaned, de-duplicated values in original order.
+        """
+        if isinstance(raw_value, list):
+            candidates = []
+            for item in raw_value:
+                candidates.extend(str(item).split(","))
+        else:
+            candidates = str(raw_value or "").split(",")
+        cleaned = []
+        seen = set()
+        for candidate in candidates:
+            value = candidate.strip()
+            if value and value not in seen:
+                seen.add(value)
+                cleaned.append(value)
+        return cleaned
+
+    def _attribute_failed_ids(
+        self,
+        not_applied: list,
+        value_to_ids: dict,
+        failed_action_ids: list,
+    ) -> None:
+        """Attribute not-applied IOC values back to their action ids.
+
+        Each profile action (destination/DNS/service) contributes one
+        or more IOC values; the bulk handler unions those values per
+        target profile before sharing them. When the push helper reports
+        values that failed or were skipped, this maps every such value
+        back to the action id(s) that contributed it and records them in
+        ``failed_action_ids`` (extended in place). A single value may
+        originate from more than one action, so every contributing id
+        is recorded.
+
+        Args:
+            not_applied (list): IOC values that failed or were skipped.
+            value_to_ids (dict): Map of IOC value to the set of action
+                ids that contributed it.
+            failed_action_ids (list): List extended in place with the
+                action ids of every not-applied value.
+        """
+        for value in not_applied:
+            failed_action_ids.extend(value_to_ids.get(value, set()))
+
+    # ------------------------------------------------------------------
+    # Destination profile helpers
+    # ------------------------------------------------------------------
+
+    def _destination_profile_capacity(
+        self,
+        existing_profiles: Dict,
+        target_profile_name: str,
+        match_type: str,
+        requested_count: int,
+        exact_total_limit: Optional[int] = None,
+    ) -> Tuple[int, str]:
+        """Compute how many values may still be added to a profile.
+
+        Mirrors the Netskope capacity model: exact-match profiles
+        (sensitive/insensitive) share a tenant-wide budget and a
+        per-profile budget, while regex profiles share a single
+        tenant-wide budget. The smaller of the relevant limits and
+        the requested count is returned, together with a label naming
+        the binding budget so callers can report exactly which limit
+        was hit.
+
+        Args:
+            existing_profiles (Dict): All destination profiles keyed
+                by name (must include ``values_count`` and ``type``).
+            target_profile_name (str): Name of the profile being
+                written to (empty for a brand new profile).
+            match_type (str): Match type of the target profile.
+            requested_count (int): Number of values the caller wants
+                to add.
+            exact_total_limit (Optional[int]): Tenant-wide exact-match
+                value limit to use instead of
+                ``DESTINATION_PROFILE_EXACT_TOTAL_LIMIT``. When ``None``
+                (the action parameter is left empty) the default
+                constant is used.
+
+        Returns:
+            Tuple[int, str]: ``(max_shareable, limit_label)`` where
+                ``max_shareable`` is the maximum number of values that
+                may be added (>= 0) and ``limit_label`` is a
+                human-readable description of the binding capacity
+                budget.
+        """
+        exact_total_limit = (
+            exact_total_limit
+            if exact_total_limit is not None
+            else DESTINATION_PROFILE_EXACT_TOTAL_LIMIT
+        )
+        if match_type in ["sensitive", "insensitive"]:
+            total_exact_usage = sum(
+                profile.get("values_count", 0)
+                for profile in existing_profiles.values()
+                if profile.get("type") in ["sensitive", "insensitive"]
+            )
+            target_usage = existing_profiles.get(
+                target_profile_name, {}
+            ).get("values_count", 0)
+            total_available = (
+                exact_total_limit
+                - total_exact_usage
+            )
+            per_profile_available = (
+                DESTINATION_PROFILE_EXACT_PER_PROFILE_LIMIT
+                - target_usage
+            )
+            # The per-profile budget is the binding one on a tie,
+            # since it is the more actionable limit for the operator.
+            if per_profile_available <= total_available:
+                limit_label = (
+                    "the per-profile value limit of "
+                    f"{DESTINATION_PROFILE_EXACT_PER_PROFILE_LIMIT}"
+                )
+            else:
+                limit_label = (
+                    "the tenant-wide exact-match value limit of "
+                    f"{exact_total_limit}"
+                )
+            max_shareable = min(
+                total_available,
+                per_profile_available,
+                requested_count,
+            )
+        else:
+            total_regex_usage = sum(
+                profile.get("values_count", 0)
+                for profile in existing_profiles.values()
+                if profile.get("type") == "regex"
+            )
+            total_regex_available = (
+                DESTINATION_PROFILE_REGEX_TOTAL_LIMIT
+                - total_regex_usage
+            )
+            limit_label = (
+                "the tenant-wide regex value limit of "
+                f"{DESTINATION_PROFILE_REGEX_TOTAL_LIMIT}"
+            )
+            max_shareable = min(
+                total_regex_available, requested_count
+            )
+        return max(0, max_shareable), limit_label
+
+    def _split_values_within_budget(
+        self,
+        values: List[str],
+        base_overhead_bytes: int,
+        budget_bytes: int,
+    ) -> Tuple[List[str], List[str]]:
+        """Split a value list at the request payload byte budget.
+
+        Greedily packs the longest prefix of ``values`` whose
+        JSON-encoded size stays within ``budget_bytes``. The running
+        size starts at ``base_overhead_bytes`` (the encoded size of the
+        surrounding request body with an empty values list) and each
+        value adds its ``json.dumps(...)`` byte length plus a 2-byte
+        item separator once the chunk already holds at least one value
+        (matching the default ``", "`` separator). Returns the prefix
+        that fits and the remaining values.
+
+        Args:
+            values (List[str]): Values to pack, in order.
+            base_overhead_bytes (int): Encoded size of the request body
+                excluding the values (the empty-list body).
+            budget_bytes (int): Maximum encoded payload size in bytes.
+
+        Returns:
+            Tuple[List[str], List[str]]: ``(chunk, remaining)`` where
+                ``chunk`` is the longest fitting prefix and ``remaining``
+                is everything that did not fit.
+        """
+        chunk_count = 0
+        current_size = base_overhead_bytes
+        item_sep_bytes = 2  # default item separator is ", "
+        for value in values:
+            encoded_len = len(json.dumps(value).encode("utf-8"))
+            delta = encoded_len + (item_sep_bytes if chunk_count else 0)
+            if current_size + delta > budget_bytes:
+                break
+            current_size += delta
+            chunk_count += 1
+        return (
+            list(values[:chunk_count]),
+            list(values[chunk_count:]),
+        )
+
+    # ------------------------------------------------------------------
+    # DNS profile helpers
+    # ------------------------------------------------------------------
+
+    def _build_dns_create_body(
+        self,
+        profile_name: str,
+        action_params: Dict,
+        action_type: str,
+        security_categories: List[Dict],
+    ) -> Dict:
+        """Build the POST body for creating a DNS profile.
+
+        Returns a skeleton body with an empty ``domain_names`` list in
+        the target ``allow_list``/``block_list`` entry; the packer
+        fills in the domains afterwards under the payload budget.
+
+        Args:
+            profile_name (str): Name for the new DNS profile.
+            action_params (Dict): Resolved action parameters.
+            action_type (str): ``add_to_allow_list`` or
+                ``add_to_block_list``.
+            security_categories (List[Dict]): Pre-parsed security
+                categories for the profile.
+
+        Returns:
+            Dict: The DNS profile create request body.
+        """
+        list_key = (
+            "allow_list"
+            if action_type == "add_to_allow_list"
+            else "block_list"
+        )
+        has_sinkhole_category = any(
+            c["action"] == "Sinkhole" for c in security_categories
+        )
+        domain_config: Dict = {
+            list_key: [
+                {
+                    "record_types": list(
+                        action_params.get("dns_record_types", [])
+                    ),
+                    "domain_names": [],
+                }
+            ],
+            "security_categories": security_categories,
+            "block_all_except_allow_list": (
+                action_params.get(
+                    "block_all_except_allow_list", "False"
+                ) == "True"
+            ),
+        }
+        if has_sinkhole_category:
+            sinkhole_ip = action_params.get(
+                "sinkhole_ip", ""
+            ).strip()
+            if sinkhole_ip:
+                domain_config["sinkhole_ip"] = sinkhole_ip
+        return {
+            "name": profile_name,
+            "description": action_params.get(
+                "new_profile_description", ""
+            ).strip(),
+            "domain_config": domain_config,
+        }
+
+    def _build_dns_patch_body(
+        self,
+        existing_profile: Dict,
+        action_params: Dict,
+        action_type: str,
+        operation: str = "append",
+        security_categories: List[Dict] = None,
+    ) -> Dict:
+        """Build a minimal-diff PATCH body for a DNS profile.
+
+        Includes only the fields that need to change. For the modified
+        list, if an existing entry has the same set of ``record_types``
+        as the user's selection, the new domains are merged into that
+        entry: for an ``append`` operation they are added to the
+        existing domains; for a ``replace`` operation the entry starts
+        empty so the new domains overwrite the existing ones for those
+        record types.
+
+        Args:
+            existing_profile (Dict): The current DNS profile object.
+            action_params (Dict): Resolved action parameters.
+            action_type (str): ``add_to_allow_list`` or
+                ``add_to_block_list``.
+            operation (str): ``append`` or ``replace``.
+            security_categories (List[Dict]): Pre-parsed security
+                categories; defaults to empty list when not provided.
+
+        Returns:
+            Dict: The DNS profile PATCH request body.
+        """
+        new_security_categories = security_categories or []
+        existing_dc = existing_profile.get("domain_config", {})
+        patch_dc: Dict = {}
+        existing_security_categories = existing_dc.get(
+            "security_categories", []
+        )
+        new_sc_pairs = {
+            (c["name"], c["action"])
+            for c in new_security_categories
+        }
+        existing_sc_pairs = {
+            (c.get("name"), c.get("action"))
+            for c in existing_security_categories
+        }
+        if new_sc_pairs != existing_sc_pairs:
+            patch_dc["security_categories"] = new_security_categories
+        has_sinkhole_category = any(
+            c["action"] == "Sinkhole"
+            for c in new_security_categories
+        )
+        new_sinkhole_ip = action_params.get(
+            "sinkhole_ip", ""
+        ).strip()
+        existing_sinkhole_ip = existing_dc.get("sinkhole_ip", "")
+        if has_sinkhole_category:
+            # A Sinkhole category is selected: send the user's IP
+            # when it differs from the value already on the profile.
+            if (
+                new_sinkhole_ip
+                and new_sinkhole_ip != existing_sinkhole_ip
+            ):
+                patch_dc["sinkhole_ip"] = new_sinkhole_ip
+        elif existing_sinkhole_ip:
+            # No Sinkhole category is selected but the profile still
+            # carries a sinkhole_ip. Clear it so the profile stays
+            # consistent with the rule that a sinkhole_ip only exists
+            # alongside a Sinkhole category.
+            patch_dc["sinkhole_ip"] = ""
+        new_block_all = (
+            action_params.get(
+                "block_all_except_allow_list", "False"
+            ) == "True"
+        )
+        if new_block_all != existing_dc.get(
+            "block_all_except_allow_list", False
+        ):
+            patch_dc["block_all_except_allow_list"] = new_block_all
+        list_key = (
+            "allow_list"
+            if action_type == "add_to_allow_list"
+            else "block_list"
+        )
+        new_record_types = list(
+            action_params.get("dns_record_types", [])
+        )
+        existing_entries = existing_dc.get(list_key, [])
+        target_entry = None
+        other_entries: List[Dict] = []
+        for entry in existing_entries:
+            if (
+                target_entry is None
+                and set(entry.get("record_types", []))
+                == set(new_record_types)
+            ):
+                target_entry = {
+                    "record_types": list(
+                        entry.get("record_types", [])
+                    ),
+                    "domain_names": (
+                        []
+                        if operation == "replace"
+                        else list(entry.get("domain_names", []))
+                    ),
+                }
+            else:
+                other_entries.append(
+                    {
+                        "record_types": list(
+                            entry.get("record_types", [])
+                        ),
+                        "domain_names": list(
+                            entry.get("domain_names", [])
+                        ),
+                    }
+                )
+        if target_entry is None:
+            target_entry = {
+                "record_types": new_record_types,
+                "domain_names": [],
+            }
+        patch_dc[list_key] = other_entries + [target_entry]
+        body: Dict = {"domain_config": patch_dc}
+        new_description = action_params.get(
+            "new_profile_description", ""
+        ).strip()
+        existing_description = existing_profile.get("description", "")
+        if new_description and new_description != existing_description:
+            body["description"] = new_description
+        return body
+
+    def _pack_domains_within_budget(
+        self,
+        body: Dict,
+        list_key: str,
+        candidate_domains: List[str],
+        budget_bytes: int,
+    ) -> tuple:
+        """Pack the longest fitting prefix of candidates into body.
+
+        Walks ``candidate_domains`` once, maintaining a running byte
+        count of the JSON-encoded body. Each domain's incremental cost
+        is its ``json.dumps`` byte length plus 2 bytes for the
+        separator (only when ``domain_names`` already has at least one
+        item). Mutates the last ``domain_config[list_key]`` entry of
+        ``body`` in place.
+
+        Args:
+            body (Dict): The create/patch body to mutate in place.
+            list_key (str): ``allow_list`` or ``block_list``.
+            candidate_domains (List[str]): Domains to attempt to add.
+            budget_bytes (int): Maximum encoded payload size in bytes.
+
+        Returns:
+            tuple: ``(accepted, skipped)`` lists of domain strings.
+        """
+        target_entry = body.get("domain_config", {}).get(
+            list_key, []
+        )[-1]
+        domain_names = target_entry["domain_names"]
+        current_size = len(json.dumps(body).encode("utf-8"))
+        if current_size > budget_bytes:
+            return [], list(candidate_domains)
+        item_sep_bytes = 2  # default item separator is ", "
+        accepted_count = 0
+        for domain in candidate_domains:
+            encoded_len = len(json.dumps(domain).encode("utf-8"))
+            delta = encoded_len + (
+                item_sep_bytes if domain_names else 0
+            )
+            if current_size + delta > budget_bytes:
+                break
+            domain_names.append(domain)
+            current_size += delta
+            accepted_count += 1
+        return (
+            list(candidate_domains[:accepted_count]),
+            list(candidate_domains[accepted_count:]),
+        )
+
+    # ------------------------------------------------------------------
+    # Device classification helpers
+    # ------------------------------------------------------------------
+
+    def _build_rule_conditions(
+        self,
+        tag_ids: List,
+        operator: str,
+        group_operator: str = "and",
+    ) -> Dict:
+        """Build the nested condition tree for a classification rule.
+
+        The tag ids are split into chunks of
+        ``DEVICE_CLASSIFICATION_TAGS_PER_GROUP`` (5). Each chunk
+        becomes a group wrapped as ``$and -> <operator> -> [checks]``
+        and all groups are joined under a top-level
+        ``<group_operator>`` container.
+
+        Args:
+            tag_ids (List): Device tag ids referenced by the rule.
+            operator (str): ``and`` or ``or`` (mapped to
+                ``$and``/``$or``) for each inner tag-check group.
+            group_operator (str): ``and`` or ``or`` for the outer
+                container that joins multiple groups.  Defaults to
+                ``"and"``.
+
+        Returns:
+            Dict: The nested ``conditions`` object for the rule body.
+        """
+        operator_key = "$or" if operator == "or" else "$and"
+        group_operator_key = (
+            "$or" if group_operator == "or" else "$and"
+        )
+        groups = []
+        for start in range(
+            0, len(tag_ids), DEVICE_CLASSIFICATION_TAGS_PER_GROUP
+        ):
+            chunk = tag_ids[
+                start:start + DEVICE_CLASSIFICATION_TAGS_PER_GROUP
+            ]
+            checks = [
+                {"device_tag_check": {"tag_id": tag_id}}
+                for tag_id in chunk
+            ]
+            groups.append({"$and": [{operator_key: checks}]})
+        return {group_operator_key: groups}
+
+    def _replace_rule_tag_checks(
+        self,
+        conditions,
+        tag_ids: List,
+        operator: str,
+        group_operator: str = "and",
+    ) -> Dict:
+        """Swap the device tag checks in an existing rule's conditions.
+
+        Updating a rule must touch ONLY its device tags and leave every
+        other condition (``min_os_version_check``,
+        ``device_not_compromised_check`` ...) untouched. EVERY existing
+        device tag check is removed from the condition tree — across all
+        groups, not just the first — and the provided ``tag_ids`` are
+        re-added as fresh groups of at most
+        ``DEVICE_CLASSIFICATION_TAGS_PER_GROUP`` checks each. The Match
+        Type operator (``operator``) applies inside each tag group; the
+        Group Match Type (``group_operator``) joins the groups at the
+        top level.
+
+        Behaviour:
+
+        - **Non-tag conditions are preserved** in place; only device
+          tag checks are stripped, and any container left empty by the
+          strip is pruned.
+        - **Multiple existing tag groups are all replaced** — the rule
+          ends with exactly the groups built from ``tag_ids`` plus the
+          surviving non-tag conditions, so no stale tag remains and no
+          tag is duplicated.
+        - **No device tag checks yet**: the new tag groups are appended
+          to the existing structure.
+        - **No usable conditions**: a fresh condition tree is built.
+
+        Args:
+            conditions: The existing rule's ``conditions`` object.
+            tag_ids (List): Device tag ids the rule should reference.
+                May exceed ``DEVICE_CLASSIFICATION_TAGS_PER_GROUP``;
+                excess ids become additional groups.
+            operator (str): ``and`` or ``or`` (mapped to
+                ``$and``/``$or``) for each inner tag group, from Match
+                Type.
+            group_operator (str): ``and`` or ``or`` for the outer
+                container joining multiple groups, from Group Match
+                Type.  Defaults to ``"and"``.
+
+        Returns:
+            Dict: A new ``conditions`` object with only the device tag
+                checks changed.
+        """
+        operator_key = "$or" if operator == "or" else "$and"
+        group_operator_key = (
+            "$or" if group_operator == "or" else "$and"
+        )
+        if not isinstance(conditions, dict) or not conditions:
+            return self._build_rule_conditions(
+                tag_ids, operator, group_operator
+            )
+
+        # Never wipe a rule's tags to empty: with no tags to apply the
+        # existing conditions are returned unchanged (the caller already
+        # guards against this, but stay defensive).
+        if not tag_ids:
+            return copy.deepcopy(conditions)
+
+        # Build the tag groups (chunks of at most
+        # DEVICE_CLASSIFICATION_TAGS_PER_GROUP) the rule must end with.
+        new_groups = []
+        for start in range(
+            0, len(tag_ids), DEVICE_CLASSIFICATION_TAGS_PER_GROUP
+        ):
+            chunk = tag_ids[
+                start:start + DEVICE_CLASSIFICATION_TAGS_PER_GROUP
+            ]
+            checks = [
+                {"device_tag_check": {"tag_id": tid}}
+                for tid in chunk
+            ]
+            new_groups.append({"$and": [{operator_key: checks}]})
+
+        new_conditions = copy.deepcopy(conditions)
+        # Rename the existing top-level operator key to match the
+        # requested Group Match Type so every group is joined by it.
+        for old_key in ("$and", "$or"):
+            if (
+                old_key in new_conditions
+                and old_key != group_operator_key
+            ):
+                new_conditions[group_operator_key] = (
+                    new_conditions.pop(old_key)
+                )
+                break
+
+        # Strip EVERY device tag check from the tree, pruning any
+        # container left empty, while keeping all non-tag conditions
+        # (min OS version, not-compromised, ...) exactly as they were.
+        # Returns the cleaned node, or None when nothing remains.
+        def _strip(node):
+            if isinstance(node, dict):
+                if "device_tag_check" in node:
+                    return None
+                cleaned = {}
+                for key, value in node.items():
+                    new_value = _strip(value)
+                    if new_value is None:
+                        continue
+                    if (
+                        isinstance(new_value, list)
+                        and not new_value
+                    ):
+                        continue
+                    cleaned[key] = new_value
+                return cleaned if cleaned else None
+            if isinstance(node, list):
+                result = []
+                for item in node:
+                    cleaned = _strip(item)
+                    if cleaned is None:
+                        continue
+                    if (
+                        isinstance(cleaned, (dict, list))
+                        and not cleaned
+                    ):
+                        continue
+                    result.append(cleaned)
+                return result
+            return node
+
+        stripped = _strip(new_conditions)
+
+        # Re-attach the freshly built tag groups to whatever non-tag
+        # structure survived. When nothing survived (the rule only ever
+        # held device tags) build a fresh tree from the new groups.
+        if not stripped or not isinstance(stripped, dict):
+            return {group_operator_key: list(new_groups)}
+        for top_key in (group_operator_key, "$and", "$or"):
+            top_value = stripped.get(top_key)
+            if isinstance(top_value, list):
+                top_value.extend(new_groups)
+                return stripped
+        # No usable top-level operator list (atypical): join the lone
+        # surviving condition with the new tag groups.
+        return {group_operator_key: [stripped] + list(new_groups)}
+
+    def _extract_rule_tag_ids(self, conditions) -> List:
+        """Collect the device tag ids referenced in a rule's conditions.
+
+        Walks the nested ``$and``/``$or`` condition tree and returns
+        every ``device_tag_check.tag_id`` found, de-duplicated with
+        order preserved.
+
+        Args:
+            conditions: The rule's ``conditions`` object (nested
+                dict/list structure).
+
+        Returns:
+            List: Device tag ids referenced by the rule, in order.
+        """
+        found = []
+        seen = set()
+
+        def _walk(node):
+            if isinstance(node, dict):
+                tag_check = node.get("device_tag_check")
+                if isinstance(tag_check, dict):
+                    tag_id = tag_check.get("tag_id")
+                    if tag_id is not None and tag_id not in seen:
+                        seen.add(tag_id)
+                        found.append(tag_id)
+                for value in node.values():
+                    _walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    _walk(item)
+
+        _walk(conditions)
+        return found
+
+    def _resolve_classification_tag_ids(
+        self,
+        tags: List[str],
+        tag_cache: Dict,
+    ) -> tuple:
+        """Resolve device tag names to their ids using a tag cache.
+
+        Device classification rules reference device tags by id. Tags
+        that do not exist are NOT created — they are reported back so
+        the caller can skip them and attribute them to the originating
+        action id(s).
+
+        Args:
+            tags (List[str]): Device tag names provided on the action.
+            tag_cache (Dict): Mapping of lower-cased tag name to
+                tag id.
+
+        Returns:
+            tuple: ``(tag_ids, not_found)`` where ``tag_ids`` are the
+                resolved ids (de-duplicated, order preserved) and
+                ``not_found`` lists the provided tag names with no
+                matching tag on the Netskope Tenant.
+        """
+        tag_ids = []
+        not_found = []
+        seen = set()
+        for tag in tags:
+            normalized = str(tag).strip().lower()
+            if not normalized:
+                continue
+            tag_stripped = str(tag).strip()
+            if (
+                not re.match(REGEX_TAG, tag_stripped)
+                or len(tag_stripped) > TAG_DEVICE_TAG_LENGTH
+            ):
+                not_found.append(tag)
+                continue
+            tag_id = tag_cache.get(normalized)
+            if tag_id is None:
+                not_found.append(tag)
+            elif tag_id not in seen:
+                seen.add(tag_id)
+                tag_ids.append(tag_id)
+        return tag_ids, not_found
+
+    def validate_tags_for_private_app(
+        self,
+        tags_to_push: List[str],
+        private_app_name: str
+    ) -> Tuple[List[Dict], List[str], int]:
+        """Validate and sanitize tags before pushing to a private app.
+
+        For each tag, the ``<`` and ``>`` characters are replaced with their
+        HTML-escaped equivalents (``&lt;`` and ``&gt;``) and the resulting
+        length is checked against ``PRIVATE_APP_TAG_MAX_LENGTH``. Tags that
+        are empty, exceed the maximum length, or raise an error during
+        length computation are skipped and recorded.
+
+        Args:
+            tags_to_push (List[str]): Tags to be validated for the private
+                app.
+            private_app_name (str): Name of the private app the tags will
+                be pushed to. Used in error/log messages for context.
+
+        Returns:
+            Tuple[List[Dict], List[str], int]: A tuple of
+                (valid_tags, skipped_tags, skip_count) where
+                ``valid_tags`` is a list of ``{"tag_name": <tag>}`` dicts
+                ready to be sent in the API payload, ``skipped_tags`` is
+                the list of tag strings that were skipped, and
+                ``skip_count`` is the total number of skipped tags
+                (including those skipped due to errors).
+        """
+        valid_tags = []
+        skipped_tags = []
+        skip_count = 0
+        for tag in tags_to_push:
+            try:
+                tag = tag.replace("<", "&lt;").replace(">", "&gt;")
+                tag_length = len(tag)
+            except Exception as err:
+                self.logger.error(
+                    f"{self.log_prefix}: Error occurred while determining"
+                    f" length of tag, hence skipped sharing tag {tag} to"
+                    f" private app {private_app_name}. Error: {err}."
+                )
+                skip_count += 1
+                continue
+            if tag_length == 0 or tag_length > PRIVATE_APP_TAG_MAX_LENGTH:
+                skipped_tags.append(tag)
+                skip_count += 1
+            else:
+                valid_tags.append({"tag_name": tag})
+        return valid_tags, skipped_tags, skip_count
+
+    def _is_valid_private_app_host(self, host: str) -> bool:
+        """Check whether a host value is valid for a private app.
+
+        A host is considered valid if it is a non-empty value that is
+        one of the following:
+        - a valid IPv4 address (e.g. ``10.0.0.1``),
+        - a valid IPv4 CIDR block no wider than ``/8`` (e.g. ``10.0.0.0/8``;
+          ``0.0.0.0/0`` and any prefix below /8 such as ``1.0.0.0/7`` are
+          rejected), or
+        - a hostname / domain (optionally a wildcard) whose total length is
+          at most 253 characters and whose every label is a valid hostname
+          label (1-63 characters of letters/digits/hyphen/underscore, not
+          starting or ending with a hyphen). A wildcard ``*`` is allowed only
+          as the leftmost label and only when the host has at least three
+          labels (e.g. ``*.netskope.com``).
+
+        IPv6 addresses and IPv6 CIDR blocks are explicitly rejected as
+        private apps do not accept IPv6 values (this also covers the IPv6
+        equivalents of ``0/0`` such as ``::`` and
+        ``0:0:0:0:0:0:0:0``).
+
+        Args:
+            host (str): Host value to validate.
+
+        Returns:
+            bool: True if the host satisfies one of the accepted formats,
+                False otherwise.
+        """
+        if not host:
+            return False
+        # Reject IPv6 addresses / CIDR blocks; private apps do not accept
+        # IPv6 values (an IPv6 literal would otherwise slip through the
+        # hostname/domain length check below).
+        try:
+            ipaddress.IPv6Interface(host)
+            return False
+        except ValueError:
+            pass
+        # Valid IPv4 address or IPv4 CIDR block (with the /8 lower bound).
+        try:
+            interface = ipaddress.IPv4Interface(host)
+        except ValueError:
+            pass
+        else:
+            return self._is_valid_private_app_ipv4(host, interface)
+        # Otherwise validate as a hostname / domain (incl. wildcard).
+        return self._is_valid_private_app_domain(host)
+
+    def _is_valid_private_app_ipv4(
+        self, host: str, interface: "ipaddress.IPv4Interface"
+    ) -> bool:
+        """Apply the private app IPv4 CIDR restrictions.
+
+        A bare IPv4 address (parsed as ``/32``) is always accepted. A CIDR
+        block is rejected when it is wider than ``/8`` (network prefix below
+        ``PRIVATE_APP_MIN_CIDR_PREFIX``) - this rejects ``0.0.0.0/0`` and
+        anything such as ``1.0.0.0/7`` while still allowing ``10.0.0.0/8``.
+
+        Args:
+            host (str): The original host value (used to detect CIDR input).
+            interface (ipaddress.IPv4Interface): The parsed interface.
+
+        Returns:
+            bool: True if the IPv4 value is acceptable, False otherwise.
+        """
+        if (
+            "/" in host
+            and interface.network.prefixlen < PRIVATE_APP_MIN_CIDR_PREFIX
+        ):
+            return False
+        return True
+
+    def _is_valid_private_app_domain(self, host: str) -> bool:
+        """Validate a private app hostname / domain (including wildcards).
+
+        Enforces the RFC length limits (total <= 253) and validates every
+        label against ``REGEX_HOSTNAME_LABEL``. A wildcard ``*`` is allowed
+        only as the leftmost label, and a wildcard host must have at least
+        three labels (e.g. ``*.netskope.com``); the ``*`` label itself is
+        stripped before the per-label check so the remaining labels are
+        validated normally.
+
+        Args:
+            host (str): Host value to validate.
+
+        Returns:
+            bool: True if the host is a valid hostname / domain, otherwise
+                False.
+        """
+        if not self.is_valid_domain_length(host):
+            return False
+        labels = host.split(".")
+        if labels[0] == "*":
+            # Wildcard must be the leftmost label of an at-least-3-part host.
+            if len(labels) < 3:
+                return False
+            labels = labels[1:]
+        # Every remaining label must be a valid hostname label (this also
+        # rejects a stray '*' anywhere other than the leftmost position).
+        return all(
+            re.match(REGEX_HOSTNAME_LABEL, label) for label in labels
+        )
+
+    def validate_hosts_for_private_app(
+        self,
+        hosts_to_push: List[str],
+        private_app_name: str
+    ) -> Tuple[List[str], List[str], int]:
+        """Validate host values before pushing to a private app.
+
+        Each host is stripped of surrounding whitespace and checked with
+        ``_is_valid_private_app_host``. Hosts that are empty, fail the
+        format/length checks, or raise an error during validation are
+        skipped and recorded.
+
+        Args:
+            hosts_to_push (List[str]): Host values to validate for the
+                private app.
+            private_app_name (str): Name of the private app the hosts will
+                be pushed to. Used in error/log messages for context.
+
+        Returns:
+            Tuple[List[str], List[str], int]: A tuple of
+                (valid_hosts, skipped_hosts, skip_count) where
+                ``valid_hosts`` is the list of accepted host values ready
+                to be sent in the API payload, ``skipped_hosts`` is the
+                list of host values that were skipped, and ``skip_count``
+                is the total number of skipped hosts (including those
+                skipped due to errors).
+        """
+        valid_hosts = []
+        skipped_hosts = []
+        skip_count = 0
+        for host in hosts_to_push:
+            try:
+                host = host.strip()
+                is_valid = self._is_valid_private_app_host(host)
+            except Exception as err:
+                self.logger.error(
+                    f"{self.log_prefix}: Error occurred while validating"
+                    f" host, hence skipped sharing host {host} to"
+                    f" private app {private_app_name}. Error: {err}."
+                )
+                skip_count += 1
+                continue
+            if not is_valid:
+                skipped_hosts.append(host)
+                skip_count += 1
+            else:
+                valid_hosts.append(host)
+        return valid_hosts, skipped_hosts, skip_count
+
+    def _validate_port(self, port):
+        """Validate the port or port range.
+
+        Args:
+            port: Port number as int/str or port range as 'lower-upper' string
+
+        Returns:
+            bool: True if port or port range is valid, False otherwise
+        """
+        # Handle port range (e.g., '1000-2000')
+        if isinstance(port, str) and '-' in port:
+            try:
+                lower, upper = port.split('-')
+                lower_port = int(lower.strip())
+                upper_port = int(upper.strip())
+                # Check if ports are within valid range
+                if not (0 <= lower_port <= 65535 and 0 <= upper_port <= 65535):
+                    return False
+                # Check if lower is less than upper and they are not equal
+                if lower_port >= upper_port:
+                    return False
+                return True
+            except (ValueError, AttributeError):
+                return False
+
+        # Handle single port
+        try:
+            port = int(port)
+            return 0 <= port <= 65535
+        except (ValueError, TypeError):
+            return False
+
+    def _build_private_app_protocols(
+        self, protocol_type, tcp_ports, udp_ports
+    ):
+        """Build the protocols payload for a private app.
+
+        Args:
+            protocol_type (list[str]): Selected protocols (TCP/UDP).
+            tcp_ports (list[str]): Ports for the TCP protocol.
+            udp_ports (list[str]): Ports for the UDP protocol.
+
+        Returns:
+            list[dict]: Protocol entries for the private app payload.
+        """
+        protocols_list = []
+        for protocol in protocol_type:
+            if protocol == "TCP":
+                protocols_list.append(
+                    {"type": "tcp", "ports": ",".join(tcp_ports)}
+                )
+            if protocol == "UDP":
+                protocols_list.append(
+                    {"type": "udp", "ports": ",".join(udp_ports)}
+                )
+        return protocols_list
+
+    def _ordered_private_app_group(self, existing_private_apps, base_name):
+        """Return the roll-over group for ``base_name`` ordered by number.
+
+        A logical private app is stored as a base app ``[base]`` plus
+        numbered roll-over siblings ``[base 2]``, ``[base 3]`` ... created
+        when the per-app host cap is hit. This collects the matching apps
+        and orders them by number (the base app counts as number 1).
+
+        Args:
+            existing_private_apps (dict): Apps keyed by stored name.
+            base_name (str): The logical app name without brackets.
+
+        Returns:
+            list[dict]: ``{name, id, number, hosts, tags, protocols,
+                publishers, use_publisher_dns}`` entries sorted by number.
+        """
+        pattern = re.compile(rf"^\[{re.escape(base_name)}( (\d+))?\]$")
+        members = []
+        for name, details in existing_private_apps.items():
+            match = pattern.match(name)
+            if not match:
+                continue
+            number = int(match.group(2)) if match.group(2) else 1
+            members.append(
+                {
+                    "name": name,
+                    "id": details.get("id", ""),
+                    "number": number,
+                    "hosts": [
+                        host for host in details.get("hosts", []) if host
+                    ],
+                    "tags": details.get("tags", []),
+                    "protocols": details.get("protocols", []),
+                    "publishers": details.get("publishers", []),
+                    "use_publisher_dns": details.get(
+                        "use_publisher_dns", False
+                    ),
+                }
+            )
+        members.sort(key=lambda member: member["number"])
+        return members
+
+    def _private_app_metadata_changed(
+        self,
+        member,
+        publishers_list,
+        use_publisher_dns,
+        protocols_list,
+        target_tag_names,
+    ):
+        """Check whether the action's metadata differs from an app's.
+
+        Compares the publishers, use-publisher-DNS flag, protocols/ports and
+        tags resolved from the action parameters against the values fetched
+        for ``member``. Returns True if any of them differs (so a PATCH is
+        warranted), False if the app already matches (the PATCH would be a
+        no-op and can be skipped).
+
+        ``protocols_list`` follows the body-builder rule: an empty list is
+        not sent and therefore never clears existing protocols, so it is
+        treated as "no protocol change".
+
+        Args:
+            member (dict): Fetched app entry (carries ``protocols``,
+                ``publishers``, ``use_publisher_dns``, ``tags``).
+            publishers_list (list[dict]): Resolved ``{publisher_id,
+                publisher_name}`` entries from the action.
+            use_publisher_dns (bool): The action's use-publisher-DNS flag.
+            protocols_list (list[dict]): ``{type, ports}`` entries built
+                from the action's protocol/port params.
+            target_tag_names (Iterable[str]): The tag names the refresh
+                would set on the app.
+
+        Returns:
+            bool: True if a metadata update is needed, else False.
+        """
+        # use-publisher-DNS flag.
+        if bool(member.get("use_publisher_dns", False)) != bool(
+            use_publisher_dns
+        ):
+            return True
+        # Publishers (compare by id set, normalised to str).
+        existing_publisher_ids = {
+            str(pub.get("publisher_id"))
+            for pub in member.get("publishers", [])
+        }
+        new_publisher_ids = {
+            str(pub.get("publisher_id")) for pub in publishers_list
+        }
+        if existing_publisher_ids != new_publisher_ids:
+            return True
+        # Protocols (compare by {(transport, port)} set). An empty
+        # protocols_list is never sent, so it is not treated as a change.
+        new_protocols = set()
+        for protocol in protocols_list:
+            transport = protocol.get("type", "")
+            for port in protocol.get("ports", "").split(","):
+                port = port.strip()
+                if port:
+                    new_protocols.add((transport, port))
+        if new_protocols:
+            existing_protocols = {
+                (proto.get("transport", ""), str(proto.get("port", "")))
+                for proto in member.get("protocols", [])
+            }
+            if new_protocols != existing_protocols:
+                return True
+        # Tags (compare by name set).
+        if set(target_tag_names) != set(member.get("tags", [])):
+            return True
+        return False
+
+    def _extract_private_app_tag_names(self, tags_field):
+        """Extract tag-name strings from a private app's ``tags`` field.
+
+        The Netskope GET response shape is handled defensively: a list of
+        plain strings, or a list of dicts keyed by ``tag_name``/``name``.
+
+        Args:
+            tags_field: The ``tags`` value from a private app record.
+
+        Returns:
+            list[str]: The tag names found (empty entries dropped).
+        """
+        names = []
+        for tag in tags_field or []:
+            if isinstance(tag, str):
+                name = tag
+            elif isinstance(tag, dict):
+                name = tag.get("tag_name") or tag.get("name") or ""
+            else:
+                name = ""
+            if name:
+                names.append(name)
+        return names
+
+    def _private_app_body(
+        self,
+        hosts,
+        host_to_tags,
+        publishers_list,
+        use_publisher_dns,
+        protocols_list,
+        base_tags=(),
+    ):
+        """Build a create/PATCH body for a private app from a host list.
+
+        The app's ``tags`` are scoped to this batch: the union of the tag
+        names contributed by the records whose hosts are in ``hosts``
+        (via ``host_to_tags``), plus any ``base_tags`` (e.g. an existing
+        app's current tags, for the Append union). Tag names are sorted
+        for determinism and rebuilt into the ``{"tag_name": ...}`` shape
+        the API expects.
+
+        Args:
+            hosts (list[str]): Hosts for this app/chunk.
+            host_to_tags (dict[str, set[str]]): host -> contributing tag
+                names.
+            publishers_list (list[dict]): Resolved publisher entries.
+            use_publisher_dns (bool): Whether to use the publisher DNS.
+            protocols_list (list[dict]): Protocol entries for the app.
+            base_tags (Iterable[str], optional): Tag names to seed the set
+                with (preserved/unioned). Defaults to empty.
+        """
+        tag_names = set(base_tags)
+        for host in hosts:
+            tag_names |= host_to_tags.get(host, set())
+        data = {
+            "host": ",".join(hosts),
+            "tags": [{"tag_name": name} for name in sorted(tag_names)],
+            "publishers": publishers_list,
+            "use_publisher_dns": use_publisher_dns,
+        }
+        if protocols_list:
+            data["protocols"] = protocols_list
+        return data


### PR DESCRIPTION
# 1.8.0 (Requires minimum Cloud Exchange version 6.1.0 and minimum Netskope Provider version 1.6.1)
## Added
- Added support for the 'Add to Destination Profile' action on Netskope.
- Added support for the 'Add to DNS Profile' action on Netskope.
- Added support for the 'Add to Service Profile' action on Netskope.
- Added support for the 'Create Device Classification' action on Netskope.
- Added coordinated cleanup of the shared client status iterator so it is removed only once no Netskope plugin (CRE or CLS) is using it.
## Changed
- Updated the 'Add Host to Private App' action to roll hosts over into additional private apps when a private app reaches its host limit, with a 'Skip Excess Hosts' option to skip the excess hosts instead.